### PR TITLE
Adding `{withr}` to improve tests that involve envvars/files.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@ as they are incompatible with CRAN (#64)
 * Removing kntir engine due to many render edge cases not being solvable
 * Adding shortcuts for REPL under addins
 * Added `db_context_command_run_and_wait`
+* Adjusted tests to use `withr` (#68)
 
 # brickster 0.2.4
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,5 +1,5 @@
 ## R CMD check results
 
-0 errors | 0 warnings | 1 note
+0 errors | 0 warnings | 0 notes
 
 * This is a new release.

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,5 @@
 library(testthat)
 library(brickster)
+library(withr)
 
 test_check("brickster")

--- a/tests/testthat/test-databricks-helpers.R
+++ b/tests/testthat/test-databricks-helpers.R
@@ -1,13 +1,23 @@
 test_that("databricks helpers - runtime detection", {
 
-  Sys.setenv("DATABRICKS_RUNTIME_VERSION" = "")
-  expect_no_error(on_databricks())
-  expect_identical(on_databricks(), FALSE)
-  expect_identical(determine_brickster_venv(), "r-brickster")
+  withr::with_envvar(
+    new = c(DATABRICKS_RUNTIME_VERSION = ""),
+    {
+      expect_no_error(on_databricks())
+      expect_identical(on_databricks(), FALSE)
+      expect_identical(determine_brickster_venv(), "r-brickster")
 
-  Sys.setenv("DATABRICKS_RUNTIME_VERSION" = "14.0")
-  expect_no_error(on_databricks())
-  expect_identical(on_databricks(), TRUE)
-  expect_null(determine_brickster_venv())
+    }
+  )
+
+  withr::with_envvar(
+    new = c(DATABRICKS_RUNTIME_VERSION = "14.0"),
+    {
+      expect_no_error(on_databricks())
+      expect_identical(on_databricks(), TRUE)
+      expect_null(determine_brickster_venv())
+
+    }
+  )
 
 })


### PR DESCRIPTION
As per #68 