### PR TITLE
Fix: `db_volume_delete`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: brickster
 Title: R Toolkit for 'Databricks'
-Version: 0.2.5
+Version: 0.2.6
 Authors@R: 
   c(
     person(given = "Zac",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# brickster 0.2.6
+* Fixing `db_volume_delete()` function (#73)
+
 # brickster 0.2.5
 
 * Adding `db_repl()` a remote REPL to a Databricks cluster (#53)

--- a/R/volume-fs.R
+++ b/R/volume-fs.R
@@ -43,7 +43,7 @@ db_volume_delete <- function(path,
   db_volume_action(
     path = path,
     action = "DELETE",
-    type = "directories",
+    type = "files",
     host = host,
     token = token,
     perform_request = perform_request


### PR DESCRIPTION
Fixes #73

Fix `db_volume_delete()` function, by changing `type` parameter of `db_volume_action()` call to files.