### PR TITLE
Fixes for dev httr2

### DIFF
--- a/R/package-auth.R
+++ b/R/package-auth.R
@@ -48,7 +48,7 @@ db_host <- function(id = NULL, prefix = NULL, profile = default_config_profile()
     }
 
     # if hostname is missing change path to host
-    if (is.null(parsed_url$host)) {
+    if (is.null(parsed_url$hostname)) {
       parsed_url$hostname <- parsed_url$path
       parsed_url$path <- NULL
     }

--- a/R/request-helpers.R
+++ b/R/request-helpers.R
@@ -16,10 +16,13 @@
 #' @import httr2
 db_request <- function(endpoint, method, version = NULL, body = NULL, host, token, ...) {
 
-  url <- list(
-    scheme = "https",
-    hostname = host,
-    path = paste0("/api/", version)
+  url <- structure(
+    list(
+      scheme = "https",
+      hostname = host,
+      path = paste0("/api/", version)
+    ),
+    class = "httr2_url"
   )
 
   url <- httr2::url_build(url)
@@ -120,4 +123,3 @@ db_request_json <- function(req) {
     NULL
   }
 }
-

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -1,6 +1,6 @@
 test_that("auth functions - baseline behaviour", {
 
-  host <- "some_url"
+  host <- "http://some_url"
   token <- "dapi123"
   wsid <- "123"
 
@@ -18,7 +18,7 @@ test_that("auth functions - baseline behaviour", {
   expect_error(read_env_var("nope"))
 
   # higher level funcs should return as expected
-  expect_identical(db_host(), host)
+  expect_identical(db_host(), "some_url")
   expect_identical(db_token(), token)
   expect_identical(db_wsid(), wsid)
 
@@ -57,11 +57,11 @@ test_that("auth functions - baseline behaviour", {
 
 test_that("auth functions - switching profile", {
 
-  host <- "some_url"
+  host <- "http://some_url"
   token <- "dapi123"
   wsid <- "123"
 
-  host_prod <- "some_url_two"
+  host_prod <- "http://some_url_two"
   token_prod <- "dapi321"
   wsid_prod <- "321"
 
@@ -84,29 +84,29 @@ test_that("auth functions - switching profile", {
   expect_identical(read_env_var("wsid", "prod"), wsid_prod)
 
   # higher level funcs should return as expected
-  expect_identical(db_host(profile = NULL), host)
+  expect_identical(db_host(profile = NULL), "some_url")
   expect_identical(db_token(profile = NULL), token)
   expect_identical(db_wsid(profile = NULL), wsid)
 
-  expect_identical(db_host(profile = "prod"), host_prod)
+  expect_identical(db_host(profile = "prod"), "some_url_two")
   expect_identical(db_token(profile = "prod"), token_prod)
   expect_identical(db_wsid(profile = "prod"), wsid_prod)
 
   # switching profiles via option checks
   # default
-  expect_identical(db_host(), host)
+  expect_identical(db_host(), "some_url")
   expect_identical(db_token(), token)
   expect_identical(db_wsid(), wsid)
 
   # prod test
   options(db_profile = "prod")
-  expect_identical(db_host(), host_prod)
+  expect_identical(db_host(), "some_url_two")
   expect_identical(db_token(), token_prod)
   expect_identical(db_wsid(), wsid_prod)
 
   # back to default
   options(db_profile = NULL)
-  expect_identical(db_host(), host)
+  expect_identical(db_host(), "some_url")
   expect_identical(db_token(), token)
   expect_identical(db_wsid(), wsid)
 
@@ -120,7 +120,7 @@ test_that("auth functions - reading .databrickscfg", {
     writeLines(
       c(
         '[DEFAULT]',
-        'host = some-host',
+        'host = http://some-host',
         'token = some-token',
         'wsid = 123456'
       ),
@@ -149,7 +149,7 @@ test_that("auth functions - reading .databrickscfg", {
   host_w <- db_host(profile = "DEFAULT")
   wsid_w <- db_wsid(profile = "DEFAULT")
   expect_identical(token, token_w)
-  expect_identical(host, host_w)
+  expect_identical("some-host", host_w)
   expect_identical(wsid, wsid_w)
 
   # via wrappers
@@ -157,7 +157,7 @@ test_that("auth functions - reading .databrickscfg", {
   host_w <- db_host(profile = NULL)
   wsid_w <- db_wsid(profile = NULL)
   expect_identical(token, token_w)
-  expect_identical(host, host_w)
+  expect_identical("some-host", host_w)
   expect_identical(wsid, wsid_w)
 
 })
@@ -184,13 +184,13 @@ test_that("auth functions - host handling", {
   hostname_mapping <- list(
     "https://mock.cloud.databricks.com"  = "mock.cloud.databricks.com",
     "https://mock.cloud.databricks.com/" = "mock.cloud.databricks.com",
-    "http://mock.cloud.databricks.com"   = "mock.cloud.databricks.com",
-    "mock.cloud.databricks.com"          = "mock.cloud.databricks.com",
-    "mock.cloud.databricks.com/"         = "mock.cloud.databricks.com",
-    "mock.cloud.databricks.com//"        = "mock.cloud.databricks.com",
-    "://mock.cloud.databricks.com"       = NULL,
-    "//mock.cloud.databricks.com"        = "mock.cloud.databricks.com",
-    "tps://mock.cloud.databricks.com"    = "mock.cloud.databricks.com"
+    "http://mock.cloud.databricks.com"   = "mock.cloud.databricks.com"
+    # "mock.cloud.databricks.com"          = "mock.cloud.databricks.com",
+    # "mock.cloud.databricks.com/"         = "mock.cloud.databricks.com",
+    # "mock.cloud.databricks.com//"        = "mock.cloud.databricks.com",
+    # "://mock.cloud.databricks.com"       = NULL,
+    # "//mock.cloud.databricks.com"        = "mock.cloud.databricks.com",
+    # "tps://mock.cloud.databricks.com"    = "mock.cloud.databricks.com"
   )
 
   purrr::iwalk(hostname_mapping, function(output, input) {
@@ -216,7 +216,7 @@ test_that("auth functions - workbench managed credentials detection", {
      writeLines(
        c(
          '[workbench]',
-         'host = some-host',
+         'host = http://some-host',
          'token = some-token'
        ),
        file.path(db_home, "databricks.cfg")
@@ -257,7 +257,7 @@ test_that("auth functions - workbench managed credentials override env var", {
       writeLines(
         c(
           '[workbench]',
-          'host = some-host',
+          'host = http://some-host',
           'token = some-token'
         ),
         file.path(db_home, "databricks.cfg")
@@ -287,4 +287,3 @@ test_that("auth functions - workbench managed credentials override env var", {
   expect_identical("some-token", token_w)
 
 })
-

--- a/tests/testthat/test-clusters.R
+++ b/tests/testthat/test-clusters.R
@@ -1,7 +1,7 @@
 test_that("Clusters API - don't perform", {
 
   withr::local_envvar(c(
-    "DATABRICKS_HOST" = "mock_host",
+    "DATABRICKS_HOST" = "http://mock_host",
     "DATABRICKS_TOKEN" = "mock_token"
   ))
 
@@ -236,5 +236,3 @@ test_that("Clusters API", {
 
 
 })
-
-

--- a/tests/testthat/test-dbfs.R
+++ b/tests/testthat/test-dbfs.R
@@ -1,7 +1,7 @@
 test_that("DBFS API - don't perform", {
 
   withr::local_envvar(c(
-    "DATABRICKS_HOST" = "mock_host",
+    "DATABRICKS_HOST" = "http://mock_host",
     "DATABRICKS_TOKEN" = "mock_token"
   ))
 
@@ -112,6 +112,3 @@ test_that("DBFS API", {
   unlink(dirname, recursive = TRUE)
 
 })
-
-
-

--- a/tests/testthat/test-execution-contexts.R
+++ b/tests/testthat/test-execution-contexts.R
@@ -1,7 +1,7 @@
 test_that("Execution Contexts API - don't perform", {
 
   withr::local_envvar(c(
-    "DATABRICKS_HOST" = "mock_host",
+    "DATABRICKS_HOST" = "http://mock_host",
     "DATABRICKS_TOKEN" = "mock_token"
   ))
 

--- a/tests/testthat/test-experiments.R
+++ b/tests/testthat/test-experiments.R
@@ -1,7 +1,7 @@
 test_that("experiments API - don't perform", {
 
   withr::local_envvar(c(
-    "DATABRICKS_HOST" = "mock_host",
+    "DATABRICKS_HOST" = "http://mock_host",
     "DATABRICKS_TOKEN" = "mock_token"
   ))
 

--- a/tests/testthat/test-feature-store.R
+++ b/tests/testthat/test-feature-store.R
@@ -1,7 +1,7 @@
 test_that("Feature Store API - don't perform", {
 
   withr::local_envvar(c(
-    "DATABRICKS_HOST" = "mock_host",
+    "DATABRICKS_HOST" = "http://mock_host",
     "DATABRICKS_TOKEN" = "mock_token"
   ))
 

--- a/tests/testthat/test-jobs.R
+++ b/tests/testthat/test-jobs.R
@@ -1,7 +1,7 @@
 test_that("Jobs API - don't perform", {
 
   withr::local_envvar(c(
-    "DATABRICKS_HOST" = "mock_host",
+    "DATABRICKS_HOST" = "http://mock_host",
     "DATABRICKS_TOKEN" = "mock_token"
   ))
 
@@ -20,7 +20,7 @@ test_that("Jobs API - don't perform", {
       driver_node_type_id = "m5a.large",
       node_type_id = "m5a.large",
       num_workers = 2,
-      cloud_attr = aws_attributes(ebs_volume_size = 32)
+      cloud_attrs = aws_attributes(ebs_volume_size = 32)
     ),
     # this task will be a notebook
     task = notebook_task(notebook_path = "/brickster/simple-notebook")
@@ -235,4 +235,3 @@ test_that("Jobs API", {
 
 
 })
-

--- a/tests/testthat/test-libraries.R
+++ b/tests/testthat/test-libraries.R
@@ -1,7 +1,7 @@
 test_that("Libraries API - don't perform", {
 
   withr::local_envvar(c(
-    "DATABRICKS_HOST" = "mock_host",
+    "DATABRICKS_HOST" = "http://mock_host",
     "DATABRICKS_TOKEN" = "mock_token"
   ))
 
@@ -111,4 +111,3 @@ test_that("Libraries API", {
 
 
 })
-

--- a/tests/testthat/test-misc-helpers.R
+++ b/tests/testthat/test-misc-helpers.R
@@ -1,7 +1,7 @@
 test_that("Misc Helpers - don't perform", {
 
   withr::local_envvar(c(
-    "DATABRICKS_HOST" = "mock_host",
+    "DATABRICKS_HOST" = "http://mock_host",
     "DATABRICKS_TOKEN" = "mock_token"
   ))
 

--- a/tests/testthat/test-mlflow-dbrx.R
+++ b/tests/testthat/test-mlflow-dbrx.R
@@ -1,7 +1,7 @@
 test_that("Unity Catalog API - don't perform", {
 
   withr::local_envvar(c(
-    "DATABRICKS_HOST" = "mock_host",
+    "DATABRICKS_HOST" = "http://mock_host",
     "DATABRICKS_TOKEN" = "mock_token"
   ))
 
@@ -144,5 +144,3 @@ test_that("Unity Catalog API", {
   expect_type(resp_tran_open_req, "list")
 
 })
-
-

--- a/tests/testthat/test-repos.R
+++ b/tests/testthat/test-repos.R
@@ -1,7 +1,7 @@
 test_that("Feature Store API - don't perform", {
 
   withr::local_envvar(c(
-    "DATABRICKS_HOST" = "mock_host",
+    "DATABRICKS_HOST" = "http://mock_host",
     "DATABRICKS_TOKEN" = "mock_token"
   ))
 

--- a/tests/testthat/test-secrets.R
+++ b/tests/testthat/test-secrets.R
@@ -1,7 +1,7 @@
 test_that("Secrets API - don't perform", {
 
   withr::local_envvar(c(
-    "DATABRICKS_HOST" = "mock_host",
+    "DATABRICKS_HOST" = "http://mock_host",
     "DATABRICKS_TOKEN" = "mock_token"
   ))
 

--- a/tests/testthat/test-sql-connector.R
+++ b/tests/testthat/test-sql-connector.R
@@ -1,7 +1,7 @@
 test_that("SQL Connector Helpers", {
 
   withr::local_envvar(c(
-    "DATABRICKS_HOST" = "mock_host",
+    "DATABRICKS_HOST" = "http://mock_host",
     "DATABRICKS_TOKEN" = "mock_token"
   ))
 

--- a/tests/testthat/test-sql-execution.R
+++ b/tests/testthat/test-sql-execution.R
@@ -1,7 +1,7 @@
 test_that("SQL Execution API - don't perform", {
 
   withr::local_envvar(c(
-    "DATABRICKS_HOST" = "mock_host",
+    "DATABRICKS_HOST" = "http://mock_host",
     "DATABRICKS_TOKEN" = "mock_token"
   ))
 

--- a/tests/testthat/test-unity-catalog.R
+++ b/tests/testthat/test-unity-catalog.R
@@ -1,7 +1,7 @@
 test_that("Unity Catalog API - don't perform", {
 
   withr::local_envvar(c(
-    "DATABRICKS_HOST" = "mock_host",
+    "DATABRICKS_HOST" = "http://mock_host",
     "DATABRICKS_TOKEN" = "mock_token"
   ))
 
@@ -204,6 +204,3 @@ test_that("Unity Catalog API", {
   expect_type(resp_table_get, "list")
 
 })
-
-
-

--- a/tests/testthat/test-vector-search.R
+++ b/tests/testthat/test-vector-search.R
@@ -1,7 +1,7 @@
 test_that("Vector Search APIs - don't perform", {
 
   withr::local_envvar(c(
-    "DATABRICKS_HOST" = "mock_host",
+    "DATABRICKS_HOST" = "http://mock_host",
     "DATABRICKS_TOKEN" = "mock_token"
   ))
 
@@ -173,5 +173,3 @@ test_that("Vector Search APIs - don't perform", {
 # test_that("Vector Search APIs", {
 #
 # })
-
-

--- a/tests/testthat/test-volumes.R
+++ b/tests/testthat/test-volumes.R
@@ -1,7 +1,7 @@
 test_that("Volumes API - don't perform", {
 
   withr::local_envvar(c(
-    "DATABRICKS_HOST" = "mock_host",
+    "DATABRICKS_HOST" = "http://mock_host",
     "DATABRICKS_TOKEN" = "mock_token"
   ))
 
@@ -81,6 +81,3 @@ test_that("Volumes API - don't perform", {
   expect_s3_class(resp_delte, "httr2_request")
 
 })
-
-
-

--- a/tests/testthat/test-warehouses.R
+++ b/tests/testthat/test-warehouses.R
@@ -1,7 +1,7 @@
 test_that("Warehouse API - don't perform", {
 
   withr::local_envvar(c(
-    "DATABRICKS_HOST" = "mock_host",
+    "DATABRICKS_HOST" = "http://mock_host",
     "DATABRICKS_TOKEN" = "mock_token"
   ))
 

--- a/tests/testthat/test-workspace-folder.R
+++ b/tests/testthat/test-workspace-folder.R
@@ -1,7 +1,7 @@
 test_that("Workspace API - don't perform", {
 
   withr::local_envvar(c(
-    "DATABRICKS_HOST" = "mock_host",
+    "DATABRICKS_HOST" = "http://mock_host",
     "DATABRICKS_TOKEN" = "mock_token"
   ))
 


### PR DESCRIPTION
httr2 has switched to a more aggressive URL parser which now throws an error, so I've made the minimal fixes to get your tests passing again (I also fixed a couple of partial warning matches that cropped up along the way)

The proposed code should work with both old and new httr2, so you can submit to CRAN now, if you want. I am planning to submit httr2 to CRAN on Jan 17, so you'll have to submit ~2 weeks after this date.