### PR TITLE
Fix for upcoming httr2 1.2.0

### DIFF
--- a/tests/testthat/test-request-helpers.R
+++ b/tests/testthat/test-request-helpers.R
@@ -27,8 +27,12 @@ test_that("request helpers - building requests", {
   expect_identical(req$body$data, body)
   expect_no_error(req$options$useragent)
   expect_equal(req$policies$retry_max_tries, 3)
-  expect_equal(req$headers$Authorization, paste("Bearer", token))
-
+  if (packageVersion("httr2") >= "1.1.2.9000") {
+    headers <- httr2::req_get_headers(req, "reveal")
+  } else {
+    headers <- req$headers
+  }
+  expect_equal(headers$Authorization, paste("Bearer", token))
 
   req_json <- db_request_json(req)
   expect_equal(unclass(req_json), "{\"a\":1,\"b\":2}")


### PR DESCRIPTION
httr2 now puts redacted headers inside a weakref which means that they can't accidentally be serialized to disk. It also exposes a new `req_get_headers()` accessor in order to get to the actual value if needed.