### PR TITLE
Let NULL token on DatabricksConnection

### DIFF
--- a/R/databricks-dbi.R
+++ b/R/databricks-dbi.R
@@ -11,6 +11,7 @@
 NULL
 
 # S4 Class Definitions --------------------------------------------------------
+setClassUnion("characterOrNULL", c("character", "NULL"))
 
 #' DBI Driver for Databricks
 #' @export
@@ -24,7 +25,7 @@ setClass(
   slots = list(
     warehouse_id = "character",
     host = "character",
-    token = "character",
+    token = "characterOrNULL",
     catalog = "character",
     schema = "character",
     staging_volume = "character"

--- a/R/databricks-dbi.R
+++ b/R/databricks-dbi.R
@@ -157,9 +157,7 @@ setMethod("dbIsValid", "DatabricksConnection", function(dbObj, ...) {
   !is.null(dbObj@warehouse_id) &&
     nchar(dbObj@warehouse_id) > 0 &&
     !is.null(dbObj@host) &&
-    nchar(dbObj@host) > 0 &&
-    !is.null(dbObj@token) &&
-    nchar(dbObj@token) > 0
+    nchar(dbObj@host) > 0
 })
 
 

--- a/R/databricks-dbi.R
+++ b/R/databricks-dbi.R
@@ -371,7 +371,9 @@ setMethod("dbFetch", "DatabricksResult", function(res, n = -1, ...) {
     cli::cli_progress_step("Executing query")
     status <- db_sql_exec_poll_for_success(
       res@statement_id,
-      show_progress = FALSE
+      show_progress = FALSE,
+      host = res@connection@host,
+      token = res@connection@token
     )
   } else {
     # Already completed

--- a/R/sql-query-execution.R
+++ b/R/sql-query-execution.R
@@ -496,6 +496,8 @@ db_sql_fetch_results <- function(
     .x = seq.int(total_chunks, from = 0),
     .f = db_sql_exec_result,
     statement_id = statement_id,
+    host = host,
+    token = token,
     perform_request = FALSE
   )
 

--- a/R/sql-query-execution.R
+++ b/R/sql-query-execution.R
@@ -264,13 +264,15 @@ db_sql_exec_result <- function(
 db_sql_exec_poll_for_success <- function(
   statement_id,
   interval = 1,
-  show_progress = TRUE
+  show_progress = TRUE,
+  host = db_host(),
+  token = db_token()
 ) {
   is_query_running <- TRUE
 
   while (is_query_running) {
     Sys.sleep(interval)
-    status <- db_sql_exec_status(statement_id = statement_id)
+    status <- db_sql_exec_status(statement_id = statement_id, host=host, token=token)
 
     if (status$status$state == "SUCCEEDED") {
       is_query_running <- FALSE
@@ -348,7 +350,9 @@ db_sql_exec_and_wait <- function(
     }
     resp <- db_sql_exec_poll_for_success(
       resp$statement_id,
-      show_progress = FALSE
+      show_progress = FALSE,
+      host = host,
+      token = token
     )
   }
 

--- a/man/db_sql_exec_poll_for_success.Rd
+++ b/man/db_sql_exec_poll_for_success.Rd
@@ -4,7 +4,13 @@
 \alias{db_sql_exec_poll_for_success}
 \title{Poll a Query Until Successful}
 \usage{
-db_sql_exec_poll_for_success(statement_id, interval = 1, show_progress = TRUE)
+db_sql_exec_poll_for_success(
+  statement_id,
+  interval = 1,
+  show_progress = TRUE,
+  host = db_host(),
+  token = db_token()
+)
 }
 \arguments{
 \item{statement_id}{String, query execution \code{statement_id}}
@@ -12,6 +18,10 @@ db_sql_exec_poll_for_success(statement_id, interval = 1, show_progress = TRUE)
 \item{interval}{Number of seconds between status checks.}
 
 \item{show_progress}{If TRUE, show progress updates during polling (default: TRUE)}
+
+\item{host}{Databricks workspace URL, defaults to calling \code{\link[=db_host]{db_host()}}.}
+
+\item{token}{Databricks workspace token, defaults to calling \code{\link[=db_token]{db_token()}}.}
 }
 \description{
 Poll a Query Until Successful


### PR DESCRIPTION
If there is a `NULL` token then brickster uses oauth.  (by default `db_token()` returns `NULL` when no access token is set) 

Closes #122 