### PR TITLE
Allow passing custom request options

### DIFF
--- a/R/request-helpers.R
+++ b/R/request-helpers.R
@@ -10,6 +10,20 @@
 #' @param token Databricks token, defaults to [db_token()].
 #' @param ... Parameters passed on to [httr2::req_body_json()] when `body` is not `NULL`.
 #'
+#' @details
+#'
+#' If you need to pass advanced options to the request, you can use the
+#' option `"brickster.request.options"`. For instance, to force HTTP/1.1 you can
+#' use:
+#'
+#' ```
+#' options("brickster.request.options" = list(
+#'   http_version = curl::curl_symbols("CURL_HTTP_VERSION_1_1")$value)
+#' )
+#' ```
+#'
+#' These options will be passed to [httr2::req_options()].
+#'
 #' @family Request Helpers
 #'
 #' @return request
@@ -34,6 +48,11 @@ db_request <- function(endpoint, method, version = NULL, body = NULL, host, toke
     httr2::req_url_path_append(endpoint) |>
     httr2::req_method(method) |>
     httr2::req_retry(max_tries = 3, backoff = ~ 2)
+
+  req_opt <- getOption("brickster.request.options")
+  if (!is.null(req_opt)) {
+    req <- do.call(httr2::req_options, c(list(req), req_opt))
+  }
 
   # if token is present use directly
   # otherwise initiate OAuth 2.0 U2M Workspace flow

--- a/man/db_request.Rd
+++ b/man/db_request.Rd
@@ -27,6 +27,18 @@ request
 \description{
 Databricks Request Helper
 }
+\details{
+If you need to pass advanced options to the request, you can use the
+option \code{"brickster.request.options"}. For instance, to force HTTP/1.1 you can
+use:
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{options("brickster.request.options" = list(
+  http_version = curl::curl_symbols("CURL_HTTP_VERSION_1_1")$value)
+)
+}\if{html}{\out{</div>}}
+
+These options will be passed to \code{\link[httr2:req_options]{httr2::req_options()}}.
+}
 \seealso{
 Other Request Helpers: 
 \code{\link{db_perform_request}()},


### PR DESCRIPTION
On the corporate environment where I am using brickster, some of the requests fail with the error message:

> Error in the HTTP2 framing layer

I have not been able to create a reproducible example of the issue. The same request sometimes triggers an error sometimes it does not.

The error may be caused by some internal firewall/routing issue or by a bug in curl. But debugging that is hard right now for me.

With this commit I can force using http 1.1 instead of http 2:

```r
options("brickster.request.options" = list(
  http_version = curl::curl_symbols("CURL_HTTP_VERSION_1_1")$value)
)
```

Long term, the best approach is to fix this http2 issue, but it can take months for me to understand the root cause and contribute a fix.

The CRAN curl package maintainer already [pointed out](https://github.com/jeroen/curl/issues/424) that setting options across all curl requests through a global variable was not an option for this use case, so my best approach right now is to implement a fix at the brickster level.

Would you consider reviewing/merging this pull request?

Thanks!