### PR TITLE
perf: don't check names in data.frame constructor

### DIFF
--- a/R/connection-pane.R
+++ b/R/connection-pane.R
@@ -36,15 +36,17 @@ get_catalogs <- function(host, token) {
   catalogs <- db_uc_catalogs_list(host = host, token = token)
   data.frame(
     name = purrr::map_chr(catalogs, "name"),
-    type = "catalog"
+    type = "catalog",
+    check.names = FALSE
   )
   if (length(catalogs) > 0) {
     data.frame(
       name = purrr::map_chr(catalogs, "name"),
-      type = "catalog"
+      type = "catalog",
+      check.names = FALSE
     )
   } else {
-    data.frame(name = NULL, type = NULL)
+    data.frame(name = NULL, type = NULL, check.names = FALSE)
   }
 }
 
@@ -57,10 +59,11 @@ get_schemas <- function(catalog, host, token) {
   if (length(schemas) > 0) {
     data.frame(
       name = purrr::map_chr(schemas, "name"),
-      type = "schema"
+      type = "schema",
+      check.names = FALSE
     )
   } else {
-    data.frame(name = NULL, type = NULL)
+    data.frame(name = NULL, type = NULL, check.names = FALSE)
   }
 }
 
@@ -74,10 +77,11 @@ get_tables <- function(catalog, schema, host, token) {
   if (length(tables) > 0) {
     data.frame(
       name = purrr::map_chr(tables, "name"),
-      type = "table"
+      type = "table",
+      check.names = FALSE
     )
   } else {
-    data.frame(name = NULL, type = NULL)
+    data.frame(name = NULL, type = NULL, check.names = FALSE)
   }
 }
 
@@ -91,10 +95,11 @@ get_uc_models <- function(catalog, schema, host, token) {
   if (length(models) > 0) {
     data.frame(
       name = purrr::map_chr(models, "name"),
-      type = "model"
+      type = "model",
+      check.names = FALSE
     )
   } else {
-    data.frame(name = NULL, type = NULL)
+    data.frame(name = NULL, type = NULL, check.names = FALSE)
   }
 }
 
@@ -118,7 +123,8 @@ get_uc_model <- function(catalog, schema, model, host, token) {
 
   data.frame(
     name = names(info),
-    type = unname(unlist(info))
+    type = unname(unlist(info)),
+    check.names = FALSE
   )
 }
 
@@ -157,7 +163,8 @@ get_uc_model_versions <- function(catalog, schema, model, host, token,
 
     res <- data.frame(
       name = version_names,
-      type = "version"
+      type = "version",
+      check.names = FALSE
     )
 
   } else {
@@ -176,7 +183,8 @@ get_uc_model_versions <- function(catalog, schema, model, host, token,
 
     res <- data.frame(
       name = names(info),
-      type = unname(unlist(info))
+      type = unname(unlist(info)),
+      check.names = FALSE
     )
 
   }
@@ -195,10 +203,11 @@ get_uc_functions <- function(catalog, schema, host, token) {
   if (length(funcs) > 0) {
     data.frame(
       name = purrr::map_chr(funcs, "name"),
-      type = "func"
+      type = "func",
+      check.names = FALSE
     )
   } else {
-    data.frame(name = NULL, type = NULL)
+    data.frame(name = NULL, type = NULL, check.names = FALSE)
   }
 }
 
@@ -223,7 +232,8 @@ get_uc_function <- function(catalog, schema, func, host, token) {
 
   data.frame(
     name = names(info),
-    type = unname(unlist(info))
+    type = unname(unlist(info)),
+    check.names = FALSE
   )
 }
 
@@ -237,10 +247,11 @@ get_uc_volumes <- function(catalog, schema, host, token) {
   if (length(volumes) > 0) {
     data.frame(
       name = purrr::map_chr(volumes, "name"),
-      type = "volume"
+      type = "volume",
+      check.names = FALSE
     )
   } else {
-    data.frame(name = NULL, type = NULL)
+    data.frame(name = NULL, type = NULL, check.names = FALSE)
   }
 }
 
@@ -267,7 +278,8 @@ get_uc_volume <- function(catalog, schema, host, volume, token) {
 
   data.frame(
     name = names(info),
-    type = unname(unlist(info))
+    type = unname(unlist(info)),
+    check.names = FALSE
   )
 }
 
@@ -287,7 +299,8 @@ get_schema_objects <- function(catalog, schema, host, token) {
 
   data.frame(
     name = unname(sizes),
-    type = names(sizes)
+    type = names(sizes),
+    check.names = FALSE
   )
 
 }
@@ -379,7 +392,8 @@ get_table_data <- function(catalog, schema, table, host, token, metadata = TRUE)
 
   data.frame(
     name = names(info),
-    type = unname(unlist(info))
+    type = unname(unlist(info)),
+    check.names = FALSE
   )
 
 }
@@ -390,7 +404,8 @@ get_experiments <- function(host, token) {
   exp_ids <-  purrr::map_chr(experiments, "experiment_id")
   data.frame(
     name = paste0(gsub(".*\\/(.*)", "\\1", exp_names), " (", exp_ids, ")"),
-    type = "experiment"
+    type = "experiment",
+    check.names = FALSE
   )
 }
 
@@ -409,7 +424,8 @@ get_experiment <- function(id, host, token) {
 
   data.frame(
     name = names(info),
-    type = unname(unlist(info))
+    type = unname(unlist(info)),
+    check.names = FALSE
   )
 }
 
@@ -423,7 +439,8 @@ get_models <- function(host, token) {
   models <- models$registered_models
   data.frame(
     name = purrr::map_chr(models, "name"),
-    type = "model"
+    type = "model",
+    check.names = FALSE
   )
 }
 
@@ -446,7 +463,8 @@ get_model_metadata <- function(id, host, token) {
 
   data.frame(
     name = names(info),
-    type = unname(unlist(info))
+    type = unname(unlist(info)),
+    check.names = FALSE
   )
 }
 
@@ -471,7 +489,8 @@ get_model_versions <- function(id, host, token, version = NULL) {
 
     res <- data.frame(
       name = version_names,
-      type = "version"
+      type = "version",
+      check.names = FALSE
     )
 
   } else {
@@ -491,7 +510,8 @@ get_model_versions <- function(id, host, token, version = NULL) {
 
     res <- data.frame(
       name = names(info),
-      type = unname(unlist(info))
+      type = unname(unlist(info)),
+      check.names = FALSE
     )
 
   }
@@ -527,7 +547,8 @@ get_cluster <- function(id, host, token) {
   )
   data.frame(
     name = names(info),
-    type = unname(unlist(info))
+    type = unname(unlist(info)),
+    check.names = FALSE
   )
 }
 
@@ -557,7 +578,8 @@ get_warehouse <- function(id, host, token) {
   )
   data.frame(
     name = names(info),
-    type = unname(unlist(info))
+    type = unname(unlist(info)),
+    check.names = FALSE
   )
 }
 
@@ -607,7 +629,8 @@ list_objects <- function(host, token,
         if (!is.null(model)) {
           objects <- data.frame(
             name = c("metadata", "versions"),
-            type = c("metadata", "versions")
+            type = c("metadata", "versions"),
+            check.names = FALSE
           )
           return(objects)
         }
@@ -621,7 +644,8 @@ list_objects <- function(host, token,
         if (!is.null(table)) {
           objects <- data.frame(
             name = c("metadata", "columns"),
-            type = c("metadata", "columns")
+            type = c("metadata", "columns"),
+            check.names = FALSE
           )
           return(objects)
         }
@@ -663,7 +687,8 @@ list_objects <- function(host, token,
     if (!is.null(model)) {
       objects <- data.frame(
         name = c("metadata", "versions"),
-        type = c("metadata", "versions")
+        type = c("metadata", "versions"),
+        check.names = FALSE
       )
       return(objects)
     }
@@ -725,7 +750,8 @@ list_objects <- function(host, token,
 
   data.frame(
     name = names(info),
-    type = unname(unlist(info))
+    type = unname(unlist(info)),
+    check.names = FALSE
   )
 
 }


### PR DESCRIPTION
Only a minor performance difference, so feel free to decline.

``` r
bench::mark(
  data.frame(x = 1, y = 2, z = 3), 
  data.frame(x = 1,  y = 2, z = 3, check.names = FALSE)
)
#> # A tibble: 2 × 6
#>   expression                             min median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                          <bch:> <bch:>     <dbl> <bch:byt>    <dbl>
#> 1 data.frame(x = 1, y = 2, z = 3)     62.2µs 65.4µs    14744.        0B     37.4
#> 2 data.frame(x = 1, y = 2, z = 3, ch… 52.9µs 57.1µs    16713.        0B     37.7
```

<sup>Created on 2026-01-08 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>