### PR TITLE
refactor: replace `c()` default in-favour of `NULL`

### DIFF
--- a/R/data-structures.R
+++ b/R/data-structures.R
@@ -1525,7 +1525,7 @@ job_tasks <- function(...) {
 job_task <- function(
   task_key,
   description = NULL,
-  depends_on = c(),
+  depends_on = NULL,
   existing_cluster_id = NULL,
   new_cluster = NULL,
   job_cluster_key = NULL,

--- a/R/feature-store.R
+++ b/R/feature-store.R
@@ -1,7 +1,7 @@
 db_feature_tables_search <- function(filter = NULL,
                                      max_results = 100,
                                      page_token = NULL,
-                                     catalog_names = c(),
+                                     catalog_names = NULL,
                                      is_multi_catalog = TRUE,
                                      host = db_host(), token = db_token(),
                                      perform_request = TRUE) {

--- a/man/job_task.Rd
+++ b/man/job_task.Rd
@@ -7,7 +7,7 @@
 job_task(
   task_key,
   description = NULL,
-  depends_on = c(),
+  depends_on = NULL,
   existing_cluster_id = NULL,
   new_cluster = NULL,
   job_cluster_key = NULL,


### PR DESCRIPTION
`c()` evaluates to `NULL` and `NULL` is more clear. Otherwise, `character()` might be a better default signaling empty character vector and being type safe.