### PR TITLE
refactor: use latest tidyverse lambda style instead of formula variant

### DIFF
--- a/R/connection-pane.R
+++ b/R/connection-pane.R
@@ -258,7 +258,7 @@ get_uc_volume <- function(catalog, schema, host, volume, token) {
     token = token
   )
 
-  volume <- purrr::keep(volumes, ~.x$name == volume)[[1]]
+  volume <- purrr::keep(volumes, \(x) x$name == volume)[[1]]
 
   info <- list(
     "name" = volume$name,
@@ -289,8 +289,8 @@ get_schema_objects <- function(catalog, schema, host, token) {
   # how many objects of each type exist
   # only show when objects exist within
   sizes <- purrr::map_int(objects, nrow) |>
-    purrr::keep(~.x > 0) |>
-    purrr::imap_chr(~ glue::glue("{.y} ({.x})"))
+    purrr::keep(\(x) x > 0) |>
+    purrr::imap_chr(\(x, y) glue::glue("{y} ({x})"))
 
   data.frame(
     name = unname(sizes),

--- a/R/databricks-dbi.R
+++ b/R/databricks-dbi.R
@@ -1119,7 +1119,7 @@ setMethod(
   signature("DatabricksConnection", "Id"),
   function(conn, x, ...) {
     # Handle schema.table identifiers
-    names <- purrr::map_chr(x@name, ~ paste0("`", .x, "`"))
+    names <- purrr::map_chr(x@name, \(x) paste0("`", x, "`"))
     DBI::SQL(paste(names, collapse = "."))
   }
 )
@@ -1479,7 +1479,7 @@ db_create_table_from_data <- function(
   }
 
   # Build column definitions
-  col_names <- purrr::map_chr(names(value), ~ dbQuoteIdentifier(conn, .x))
+  col_names <- purrr::map_chr(names(value), \(x) dbQuoteIdentifier(conn, x))
   col_defs <- paste(col_names, col_types, collapse = ", ")
 
   # Create table
@@ -1600,7 +1600,7 @@ db_create_table_as_select_values <- function(
 #' @keywords internal
 db_append_with_select_values <- function(conn, quoted_name, value) {
   # Get column names with proper quoting
-  col_names <- purrr::map_chr(names(value), ~ dbQuoteIdentifier(conn, .x))
+  col_names <- purrr::map_chr(names(value), \(x) dbQuoteIdentifier(conn, x))
   col_list <- paste(col_names, collapse = ", ")
 
   # Generate VALUES clause with type-aware formatting

--- a/R/sql-query-execution.R
+++ b/R/sql-query-execution.R
@@ -616,7 +616,7 @@ db_sql_fetch_results_parallel <- function(
 
   links <- resps |>
     purrr::map(httr2::resp_body_json) |>
-    purrr::map_chr(~ .x$external_links[[1]]$external_link) |>
+    purrr::map_chr(\(x) x$external_links[[1]]$external_link) |>
     purrr::map(function(link) {
       req <- httr2::request(link) |>
         httr2::req_retry(max_tries = 3, backoff = ~1)

--- a/tests/testthat/test-clusters.R
+++ b/tests/testthat/test-clusters.R
@@ -151,7 +151,7 @@ test_that("Clusters API", {
     purrr::map_chr(resp_list_dbrv$versions, "key"),
     decreasing = TRUE
   )
-  std_runtimes <- purrr::keep(runtimes, ~ !grepl("photon|gpu", .x))
+  std_runtimes <- purrr::keep(runtimes, \(x) !grepl("photon|gpu", x))
 
   expect_no_error({
     resp_create <- db_cluster_create(

--- a/tests/testthat/test-jobs.R
+++ b/tests/testthat/test-jobs.R
@@ -229,7 +229,7 @@ test_that("Jobs API", {
     purrr::map_chr(resp_list_dbrv$versions, "key"),
     decreasing = TRUE
   )
-  std_runtimes <- purrr::keep(runtimes, ~ !grepl("photon|gpu", .x))
+  std_runtimes <- purrr::keep(runtimes, \(x) !grepl("photon|gpu", x))
   job_clusters <- list(
     "simple_cluster" = new_cluster(
       spark_version = std_runtimes[1],

--- a/tests/testthat/test-libraries.R
+++ b/tests/testthat/test-libraries.R
@@ -66,7 +66,7 @@ test_that("Libraries API", {
     purrr::map_chr(resp_list_dbrv$versions, "key"),
     decreasing = TRUE
   )
-  std_runtimes <- purrr::keep(runtimes, ~ !grepl("photon|gpu", .x))
+  std_runtimes <- purrr::keep(runtimes, \(x) !grepl("photon|gpu", x))
   resp_create_cluster <- db_cluster_create(
     name = "brickster_test_libraries_cluster",
     spark_version = std_runtimes[1],


### PR DESCRIPTION
To match the latest tidyverse and purrr pattern.