### PR TITLE
Harden GitHub Actions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Security-sensitive GitHub Actions changes require owner review.
+.github/CODEOWNERS @zacdav-db
+.github/workflows/ @zacdav-db

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -6,6 +6,10 @@ on:
 
 name: Commands
 
+# Security note: /document and /style fetch a pull request branch and execute
+# package R code from that branch. Before triggering these commands on an
+# external contributor PR, a MEMBER or OWNER must review the PR's R code for
+# malicious constructs.
 permissions:
   contents: read
   pull-requests: read

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -13,9 +13,6 @@ permissions:
 jobs:
   test-coverage:
     environment: runtime
-    permissions:
-      contents: read
-      id-token: write # Upload coverage to Codecov via OIDC.
     runs-on:
       group: databrickslabs-protected-runner-group
       labels: linux-ubuntu-latest
@@ -52,14 +49,12 @@ jobs:
           covr::to_cobertura(cov)
         shell: Rscript {0}
 
-      - uses: codecov/codecov-action@0561704f0f02c16a585d4c7555e57fa2e44cf909 # v5.5.2
+      - name: Upload coverage report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          # Fail if error if not on PR, or if on PR and token is given
-          fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}
-          files: ./cobertura.xml
-          plugins: noop
-          disable_search: true
-          use_oidc: true
+          name: coverage-report
+          path: cobertura.xml
+          if-no-files-found: error
 
       - name: Show testthat output
         if: always()
@@ -74,3 +69,31 @@ jobs:
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package
+
+  upload-coverage:
+    needs: test-coverage
+    runs-on:
+      group: databrickslabs-protected-runner-group
+      labels: linux-ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Download coverage artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: coverage-report
+          path: coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@0561704f0f02c16a585d4c7555e57fa2e44cf909 # v5.5.2
+        with:
+          # Fail if error if not on PR, or if on PR and token is given
+          fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}
+          files: coverage/cobertura.xml
+          plugins: noop
+          disable_search: true
+          use_oidc: true

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Runbook
+
+## GitHub Actions Runtime Environment
+
+Workflows that run package code with Databricks runtime secrets must declare the
+`runtime` GitHub Actions environment. The repository settings for that
+environment must enforce required reviewers before internal GitHub Actions
+runners are enabled.
+
+Required configuration:
+
+- Environment name: `runtime`
+- Protection rule: required reviewers enabled
+- Reviewers: security owners or trusted maintainers for this repository
+- Self-review prevention: enabled when available
+
+This protects fork pull request runs by requiring an approved environment
+deployment before jobs can access `DATABRICKS_HOST`, `DATABRICKS_TOKEN`, or other
+runtime secrets.
+
+Before enabling or changing internal runners, verify the environment still has
+required reviewers configured in GitHub repository settings under
+`Settings > Environments > runtime`.
+
+## Pull Request Comment Commands
+
+The `/document` and `/style` issue-comment commands fetch the pull request branch
+and execute R code from that branch. For external contributor pull requests,
+members and owners must review the PR's R code for malicious constructs before
+triggering either command.


### PR DESCRIPTION
## Summary

Harden GitHub Actions configuration for internal runner readiness.

- Add the `runtime` environment gate to workflows that use Databricks runtime secrets.
- Document the required `runtime` environment reviewer configuration and PR command review expectations in `SECURITY.md`.
- Add a warning to `/document` and `/style` command workflows because they execute R code from pull request branches.
- Add CODEOWNERS entries so workflow and CODEOWNERS changes require `@zacdav-db` review.
- Add Dependabot configuration for weekly GitHub Actions updates.
- Split coverage generation from Codecov upload so `id-token: write` is scoped only to the upload job.

## Validation

- Parsed edited workflow YAML and Dependabot YAML with Ruby's YAML parser.
- Confirmed local `covr::package_coverage()` and `covr::to_cobertura()` functions are available for coverage report generation.
- Databricks pre-commit and pre-push secret scanning hooks passed.
