### PR TITLE
[codex] Harden public PR CI workflows

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -14,9 +14,7 @@ permissions:
 jobs:
   R-CMD-check:
     environment: runtime
-    runs-on:
-      group: databrickslabs-protected-runner-group
-      labels: ${{ matrix.config.os }}
+    runs-on: ${{ matrix.config.os }}
 
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
 
@@ -25,10 +23,10 @@ jobs:
       matrix:
         config:
           # - {os: macOS-latest,   r: 'release'}
-          - {os: windows-server-2022-latest, r: 'release'}
-          - {os: linux-ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
-          - {os: linux-ubuntu-latest,   r: 'release'}
-          - {os: linux-ubuntu-latest,   r: 'oldrel-1'}
+          - {os: windows-2022, r: 'release'}
+          - {os: ubuntu-24.04,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-24.04,   r: 'release'}
+          - {os: ubuntu-24.04,   r: 'oldrel-1'}
 
     env:
       R_KEEP_PKG_SOURCE: yes

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -20,17 +20,8 @@ jobs:
     runs-on:
       group: databrickslabs-protected-runner-group
       labels: linux-ubuntu-latest
-    env:
-      DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
-      DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
 
     steps:
-
-      - name: .Renviron file
-        run: |
-          echo DATABRICKS_HOST="$DATABRICKS_HOST" >> ~/.Renviron
-          echo DATABRICKS_TOKEN="$DATABRICKS_TOKEN" >> ~/.Renviron
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: r-lib/actions/setup-pandoc@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2.12.0

--- a/.github/workflows/pr-commands.yaml.disabled
+++ b/.github/workflows/pr-commands.yaml.disabled
@@ -1,3 +1,5 @@
+# DISABLED: this issue_comment workflow fetched PR branch code and ran it with
+# contents: write. Redesign before restoring a .yml/.yaml workflow extension.
 # Workflow derived from https://github.com/r-lib/actions/tree/master/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -13,9 +13,7 @@ permissions:
 jobs:
   test-coverage:
     environment: runtime
-    runs-on:
-      group: databrickslabs-protected-runner-group
-      labels: linux-ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
       DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
@@ -72,9 +70,7 @@ jobs:
 
   upload-coverage:
     needs: test-coverage
-    runs-on:
-      group: databrickslabs-protected-runner-group
-      labels: linux-ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary
- Move PR-capable R CMD check and coverage workflows from the Databricks protected runner group to GitHub-hosted runners.
- Use GitHub-hosted labels (`windows-2022`, `ubuntu-24.04`) for the R CMD check matrix and coverage jobs.
- Disable the `/document` and `/style` issue-comment workflow by renaming it to `pr-commands.yaml.disabled`.
- Remove `DATABRICKS_HOST` / `DATABRICKS_TOKEN` from the pkgdown deployment workflow.

## Why
Public fork PRs can execute repository code in `pull_request` workflows. Running those jobs on `databrickslabs-protected-runner-group` crosses an internal runner trust boundary before review.

The old command workflow also fetched PR branch code and ran it with `contents: write`, which mixed untrusted code execution with repository write capability. Keeping the file as `.disabled` preserves the previous implementation for a future redesign without leaving it runnable by GitHub Actions.

The pkgdown workflow did not appear to need live Databricks credentials. Static review found all vignettes set `eval = FALSE`, README examples are Markdown snippets, and `_pkgdown.yml` does not configure a live credential-dependent build step. Removing the secrets reduces credential exposure in a deploy workflow that keeps `contents: write` for publishing to `gh-pages`.

## Validation
- Parsed the active workflow YAML files with Ruby `YAML.load_file`.
- Confirmed active `.github/workflows/*.{yml,yaml}` files no longer include the issue-comment command workflow.
- Confirmed `pkgdown.yaml` no longer references `DATABRICKS_HOST`, `DATABRICKS_TOKEN`, or `.Renviron`.
- Did not run repository code or install dependencies.