### PR TITLE
[codex] Harden Actions runtime boundaries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
 # Security-sensitive GitHub Actions changes require owner review.
 .github/CODEOWNERS @zacdav-db
+.github/actions/ @zacdav-db
 .github/workflows/ @zacdav-db

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -12,11 +12,104 @@ permissions:
   contents: read
 
 jobs:
-  R-CMD-check:
+  R-CMD-check-pr:
+    if: github.event_name == 'pull_request'
+    runs-on: ${{ matrix.config.os }}
+
+    name: PR ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          # - {os: macOS-latest,   r: 'release'}
+          - {os: windows-2022, r: 'release'}
+          - {os: ubuntu-24.04,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-24.04,   r: 'release'}
+          - {os: ubuntu-24.04,   r: 'oldrel-1'}
+
+    env:
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: r-lib/actions/setup-pandoc@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2.12.0
+
+      - uses: r-lib/actions/setup-r@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2.12.0
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2.12.0
+        env:
+          GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          extra-packages: rcmdcheck
+
+      - uses: r-lib/actions/check-r-package@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2.12.0
+        env:
+          GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+  R-CMD-check-pr-required:
+    if: github.event_name == 'pull_request'
+    needs: R-CMD-check-pr
+    name: R-CMD-check-pr-required
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Confirm required PR checks passed
+        run: echo "R CMD check PR matrix passed."
+
+  R-CMD-check-pr-runtime:
+    if: github.event_name == 'pull_request'
     environment: runtime
     runs-on: ${{ matrix.config.os }}
 
-    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+    name: Runtime PR ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          # - {os: macOS-latest,   r: 'release'}
+          - {os: windows-2022, r: 'release'}
+          - {os: ubuntu-24.04,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-24.04,   r: 'release'}
+          - {os: ubuntu-24.04,   r: 'oldrel-1'}
+
+    env:
+      R_KEEP_PKG_SOURCE: yes
+      DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+      DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: r-lib/actions/setup-pandoc@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2.12.0
+
+      - uses: r-lib/actions/setup-r@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2.12.0
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2.12.0
+        env:
+          GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          extra-packages: rcmdcheck
+
+      - uses: r-lib/actions/check-r-package@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2.12.0
+        env:
+          GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+  R-CMD-check-runtime:
+    if: github.event_name == 'push'
+    environment: runtime
+    runs-on: ${{ matrix.config.os }}
+
+    name: Runtime ${{ matrix.config.os }} (${{ matrix.config.r }})
 
     strategy:
       fail-fast: false

--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -1,5 +1,3 @@
-# DISABLED: this issue_comment workflow fetched PR branch code and ran it with
-# contents: write. Redesign before restoring a .yml/.yaml workflow extension.
 # Workflow derived from https://github.com/r-lib/actions/tree/master/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
@@ -8,10 +6,6 @@ on:
 
 name: Commands
 
-# Security note: /document and /style fetch a pull request branch and execute
-# package R code from that branch. Before triggering these commands on an
-# external contributor PR, a MEMBER or OWNER must review the PR's R code for
-# malicious constructs.
 permissions:
   contents: read
   pull-requests: read
@@ -20,12 +14,7 @@ jobs:
   document:
     if: ${{ github.event.issue.pull_request && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER') && startsWith(github.event.comment.body, '/document') }}
     name: document
-    permissions:
-      contents: write # Push generated documentation updates back to the PR branch.
-      pull-requests: read
-    runs-on:
-      group: databrickslabs-protected-runner-group
-      labels: linux-ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -41,31 +30,30 @@ jobs:
         env:
           GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
         with:
-          extra-packages: roxygen2
+          extra-packages: any::roxygen2
 
       - name: Document
         run: Rscript -e 'roxygen2::roxygenise()'
 
-      - name: commit
+      - name: Create documentation patch
         run: |
-          git config --local user.name "$GITHUB_ACTOR"
-          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          git add man/\* NAMESPACE
-          git commit -m 'Document'
+          git diff --binary -- man NAMESPACE > document.patch
+          if [ ! -s document.patch ]; then
+            echo "No documentation changes generated." > document.patch
+          fi
+        shell: bash
 
-      - uses: r-lib/actions/pr-push@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2.12.0
+      - name: Upload documentation patch
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          name: document-patch-${{ github.event.issue.number }}
+          path: document.patch
+          if-no-files-found: error
 
   style:
     if: ${{ github.event.issue.pull_request && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER') && startsWith(github.event.comment.body, '/style') }}
     name: style
-    permissions:
-      contents: write # Push formatting updates back to the PR branch.
-      pull-requests: read
-    runs-on:
-      group: databrickslabs-protected-runner-group
-      labels: linux-ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -74,20 +62,29 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: r-lib/actions/setup-r@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2.12.0
+        with:
+          use-public-rspm: true
 
-      - name: Install dependencies
-        run: Rscript -e 'install.packages("styler")'
+      - uses: r-lib/actions/setup-r-dependencies@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2.12.0
+        env:
+          GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          extra-packages: any::styler
 
       - name: Style
         run: Rscript -e 'styler::style_pkg()'
 
-      - name: commit
+      - name: Create style patch
         run: |
-          git config --local user.name "$GITHUB_ACTOR"
-          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          git add \*.R
-          git commit -m 'Style'
+          git diff --binary -- '*.R' > style.patch
+          if [ ! -s style.patch ]; then
+            echo "No style changes generated." > style.patch
+          fi
+        shell: bash
 
-      - uses: r-lib/actions/pr-push@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2.12.0
+      - name: Upload style patch
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          name: style-patch-${{ github.event.issue.number }}
+          path: style.patch
+          if-no-files-found: error

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -12,6 +12,106 @@ permissions:
 
 jobs:
   test-coverage:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    env:
+      NOT_CRAN: TRUE
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - uses: r-lib/actions/setup-r@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2.12.0
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2.12.0
+        env:
+          GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          extra-packages: any::covr, any::xml2
+          needs: coverage
+
+      - name: Test coverage
+        run: |
+          cov <- covr::package_coverage(
+            quiet = FALSE,
+            clean = FALSE,
+            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
+          )
+          print(cov)
+          covr::to_cobertura(cov)
+        shell: Rscript {0}
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-report
+          path: cobertura.xml
+          if-no-files-found: error
+
+      - name: Show testthat output
+        if: always()
+        run: |
+          ## --------------------------------------------------------------------
+          find '${{ runner.temp }}/package' -name 'testthat.Rout*' -exec cat '{}' \; || true
+        shell: bash
+
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-test-failures
+          path: ${{ runner.temp }}/package
+
+  test-coverage-pr-required:
+    if: github.event_name == 'pull_request'
+    needs: test-coverage
+    name: test-coverage-pr-required
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Confirm required PR coverage passed
+        run: echo "Coverage PR job passed."
+
+  test-coverage-pr-runtime:
+    if: github.event_name == 'pull_request'
+    environment: runtime
+    runs-on: ubuntu-24.04
+    env:
+      DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
+      DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
+      DATABRICKS_WSID: ${{ secrets.DATABRICKS_WSID }}
+      NOT_CRAN: TRUE
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - uses: r-lib/actions/setup-r@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2.12.0
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2.12.0
+        env:
+          GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          extra-packages: any::covr, any::xml2
+          needs: coverage
+
+      - name: Test coverage
+        run: |
+          cov <- covr::package_coverage(
+            quiet = FALSE,
+            clean = FALSE,
+            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
+          )
+          print(cov)
+        shell: Rscript {0}
+
+  test-coverage-runtime:
+    if: github.event_name == 'push'
     environment: runtime
     runs-on: ubuntu-24.04
     env:
@@ -69,7 +169,8 @@ jobs:
           path: ${{ runner.temp }}/package
 
   upload-coverage:
-    needs: test-coverage
+    if: always() && !cancelled()
+    needs: [test-coverage, test-coverage-runtime]
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,10 +2,15 @@
 
 ## GitHub Actions Runtime Environment
 
-Workflows that run package code with Databricks runtime secrets must declare the
-`runtime` GitHub Actions environment. The repository settings for that
-environment must enforce required reviewers before internal GitHub Actions
-runners are enabled.
+Default pull request checks must run without Databricks runtime secrets. Pull
+request jobs may run package code with `DATABRICKS_HOST`, `DATABRICKS_TOKEN`,
+`DATABRICKS_WSID`, or other runtime secrets only when they declare the `runtime`
+environment and an environment reviewer approves the run.
+
+Trusted workflows that run package code with Databricks runtime secrets must
+declare the `runtime` GitHub Actions environment. The repository settings for
+that environment must enforce required reviewers before runtime secrets or
+internal GitHub Actions runners are enabled.
 
 Required configuration:
 
@@ -14,9 +19,10 @@ Required configuration:
 - Reviewers: security owners or trusted maintainers for this repository
 - Self-review prevention: enabled when available
 
-This protects fork pull request runs by requiring an approved environment
-deployment before jobs can access `DATABRICKS_HOST`, `DATABRICKS_TOKEN`, or other
-runtime secrets.
+This keeps default fork and pull request checks outside the Databricks trust
+boundary. Runtime jobs may execute repository code with `DATABRICKS_HOST`,
+`DATABRICKS_TOKEN`, or other runtime secrets only after the environment gate has
+been approved.
 
 Before enabling or changing internal runners, verify the environment still has
 required reviewers configured in GitHub repository settings under
@@ -25,6 +31,27 @@ required reviewers configured in GitHub repository settings under
 ## Pull Request Comment Commands
 
 The `/document` and `/style` issue-comment commands fetch the pull request branch
-and execute R code from that branch. For external contributor pull requests,
-members and owners must review the PR's R code for malicious constructs before
-triggering either command.
+and execute R code from that branch. These workflows must stay artifact-only:
+
+- run only on GitHub-hosted runners;
+- use only read-only repository permissions;
+- never declare the `runtime` environment;
+- never receive Databricks runtime secrets;
+- never push directly to the pull request branch.
+
+Members and owners may use the generated patch artifact after reviewing it. Do
+not restore an auto-push command unless it is limited to same-repository PR
+branches after validating the PR head repository through the GitHub API.
+
+## Branch Protection
+
+The default branch must require pull request review and status checks before
+merge. Required configuration:
+
+- Require at least one approving review.
+- Require CODEOWNERS review for `.github/workflows/`, `.github/actions/`, and
+  `.github/CODEOWNERS`.
+- Require CI status checks that cover R CMD check and coverage before merge:
+  `R-CMD-check-pr-required` and `test-coverage-pr-required`.
+- Dismiss stale reviews or require approval of the latest pushed commit.
+- Restrict who can bypass required pull requests and status checks.


### PR DESCRIPTION
## Summary

- split default PR checks from environment-gated Databricks runtime checks
- replace the disabled comment-command workflow with an artifact-only `/document` and `/style` workflow
- document the runtime trust boundary and enforce workflow ownership through CODEOWNERS

## Security impact

Default PR jobs no longer receive Databricks runtime secrets. Maintainers can still approve environment-gated PR runtime jobs when Databricks-backed validation is required. The comment-command workflow no longer runs on protected runners, no longer has write permissions, and no longer pushes to PR branches.

## Validation

- Parsed all workflow YAML files with Ruby YAML parser
- Existing Databricks secret-scanning hooks passed during commit and push

Note: package tests were not run because this change only touches GitHub Actions configuration and security policy, and repo code/dependency execution was intentionally avoided during the supply-chain hardening pass.
