### PR TITLE
Enable db_request retries on request failures

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # brickster 0.2.13
 
+-   Enabled `db_request()` retries for transient low-level HTTP request failures, improving resilience to intermittent curl/HTTP2 framing errors (#215)
 -   Added Azure AD service principal OAuth M2M support (`ARM_CLIENT_ID`, `ARM_CLIENT_SECRET`, `ARM_TENANT_ID`) with optional `DATABRICKS_AUTH_TYPE` override (`oauth-m2m`, `azure-client-secret`, `oauth-u2m`); default auth resolution now prefers Azure M2M over U2M when ARM credentials are present (#185)
 -   Marked DBFS REST wrappers (`db_dbfs_*`) as deprecated and moved them to internal-only, guiding users towards using volumes (`db_volume_*`)
 -   Added `db_volume_download_dir()` for parallel directory downloads from Unity Catalog volumes to local directories

--- a/R/request-helpers.R
+++ b/R/request-helpers.R
@@ -40,7 +40,7 @@ db_request <- function(
     httr2::req_user_agent(string = user_agent_str) |>
     httr2::req_url_path_append(endpoint) |>
     httr2::req_method(method) |>
-    httr2::req_retry(max_tries = 3, backoff = ~2)
+    httr2::req_retry(max_tries = 3, backoff = ~2, retry_on_failure = TRUE)
 
   # if token is present use directly
   # otherwise initiate OAuth 2.0 U2M or M2M Workspace flow

--- a/tests/testthat/test-request-helpers.R
+++ b/tests/testthat/test-request-helpers.R
@@ -45,6 +45,7 @@ test_that("request helpers - building requests", {
   expect_identical(req$body$data, body)
   expect_no_error(req$options$useragent)
   expect_equal(req$policies$retry_max_tries, 3)
+  expect_true(req$policies$retry_on_failure)
   req_json <- db_request_json(req)
   expect_equal(unclass(req_json), "{\"a\":1,\"b\":2}")
   expect_s3_class(req_json, "json")


### PR DESCRIPTION
## Summary

- Enables `retry_on_failure = TRUE` for the shared `db_request()` retry policy.
- Adds a request-shape assertion so the retry-on-failure policy stays covered.
- Updates NEWS for the user-visible resilience improvement.

Fixes #215.

## Validation

- `Rscript -e 'testthat::test_local(filter = "request-helpers")'`\n- `Rscript -e 'testthat::test_local()'`