### PR TITLE
[codex] Update Databricks API doc links

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 -   Added a new vignette for working with volumes
 -   Added compact, colorized `{cli}` S3 print methods for `db_cluster_get()`/`db_cluster_list()`, `db_sql_warehouse_get()`/`db_sql_warehouse_list()`, and `db_jobs_get()`/`db_jobs_list()` that preserve nested list structures while improving at-a-glance summaries
 -   Standardized DBI write progress argument naming: `dbWriteTable()` and internal `db_write_table_volume()` now use `show_progress` (#201)
+-   Updated Databricks API reference links to use AWS-specific documentation routes
 
 # brickster 0.2.12
 

--- a/R/clusters.R
+++ b/R/clusters.R
@@ -89,7 +89,7 @@
 #'
 #' Cannot specify both `autoscale` and `num_workers`, must choose one.
 #'
-#' [More Documentation](https://docs.databricks.com/api/workspace/clusters/create).
+#' [More Documentation](https://docs.databricks.com/api/aws/workspace/clusters/create).
 #'
 #' @family Clusters API
 #'
@@ -811,7 +811,7 @@ db_cluster_list_zones <- function(
 #' @param end_time The end time in epoch milliseconds. If empty, returns events
 #' up to the current time.
 #' @param event_types List. Optional set of event types to filter by. Default
-#' is to return all events. [Event Types](https://docs.databricks.com/api/workspace/clusters/events#events).
+#' is to return all events. [Event Types](https://docs.databricks.com/api/aws/workspace/clusters/events#events).
 #' @param order Either `DESC` (default) or `ASC`.
 #' @param offset The offset in the result set. Defaults to 0 (no offset). When
 #' an offset is specified and the results are requested in descending order, the

--- a/R/jobs.R
+++ b/R/jobs.R
@@ -26,7 +26,7 @@
 #' @inheritParams db_sql_warehouse_create
 #'
 #' @details
-#' [Full Documentation](https://docs.databricks.com/api/workspace/jobs/create)
+#' [Full Documentation](https://docs.databricks.com/api/aws/workspace/jobs/create)
 #'
 #' @seealso [job_tasks()], [job_task()], [email_notifications()],
 #' [cron_schedule()], [access_control_request()], [access_control_req_user()],

--- a/R/query-history.R
+++ b/R/query-history.R
@@ -1,6 +1,6 @@
 #' List Warehouse Query History
 #'
-#' For more details refer to the [query history documentation](https://docs.databricks.com/api/workspace/queryhistory/list).
+#' For more details refer to the [query history documentation](https://docs.databricks.com/api/aws/workspace/queryhistory/list).
 #' This function elevates the sub-components of `filter_by` parameter to the R
 #' function directly.
 #'

--- a/R/sql-query-execution.R
+++ b/R/sql-query-execution.R
@@ -1,10 +1,10 @@
-# https://docs.databricks.com/api/workspace/statementexecution
+# https://docs.databricks.com/api/aws/workspace/statementexecution
 # https://docs.databricks.com/en/sql/admin/sql-execution-tutorial.html#language-curl
 
 #' Execute SQL Query
 #'
 #' @details Refer to the
-#' [web documentation](https://docs.databricks.com/api/workspace/statementexecution/executestatement)
+#' [web documentation](https://docs.databricks.com/api/aws/workspace/statementexecution/executestatement)
 #' for detailed material on interaction of the various parameters and general recommendations
 #'
 #' @param statement String, the SQL statement to execute. The statement can
@@ -21,7 +21,7 @@
 #' To represent a `NULL` value, the value field may be omitted or set to `NULL`
 #' explicitly.
 #'
-#' See [docs](https://docs.databricks.com/api/workspace/statementexecution/executestatement)
+#' See [docs](https://docs.databricks.com/api/aws/workspace/statementexecution/executestatement)
 #' for more details.
 #' @param row_limit Integer, applies the given row limit to the statement's
 #' result set, but unlike the `LIMIT` clause in SQL, it also sets the
@@ -34,10 +34,10 @@
 #' true. When using `EXTERNAL_LINKS` disposition, a default byte_limit of
 #' 100 GiB is applied if `byte_limit` is not explicitly set.
 #' @param disposition One of `"INLINE"` (default) or `"EXTERNAL_LINKS"`. See
-#' [docs](https://docs.databricks.com/api/workspace/statementexecution/executestatement)
+#' [docs](https://docs.databricks.com/api/aws/workspace/statementexecution/executestatement)
 #' for details.
 #' @param format One of `"JSON_ARRAY"` (default), `"ARROW_STREAM"`, or `"CSV"`.
-#' See [docs](https://docs.databricks.com/api/workspace/statementexecution/executestatement)
+#' See [docs](https://docs.databricks.com/api/aws/workspace/statementexecution/executestatement)
 #' for details.
 #' @param wait_timeout String, default is `"10s"`. The time in seconds the call
 #' will wait for the statement's result set as `Ns`, where `N` can be set to
@@ -130,7 +130,7 @@ db_sql_exec_query <- function(
 #' Requests that an executing statement be canceled. Callers must poll for
 #' status to see the terminal state.
 #'
-#' [Read more on Databricks API docs](https://docs.databricks.com/api/workspace/statementexecution/cancelexecution)
+#' [Read more on Databricks API docs](https://docs.databricks.com/api/aws/workspace/statementexecution/cancelexecution)
 #'
 #' @param statement_id String, query execution `statement_id`
 #' @inheritParams auth_params
@@ -175,7 +175,7 @@ db_sql_exec_cancel <- function(
 #' After at least 12 hours in terminal state, the statement is removed from the
 #' warehouse and further calls will receive an HTTP `404` response.
 #'
-#' [Read more on Databricks API docs](https://docs.databricks.com/api/workspace/statementexecution/getstatement)
+#' [Read more on Databricks API docs](https://docs.databricks.com/api/aws/workspace/statementexecution/getstatement)
 #'
 #' @inheritParams auth_params
 #' @inheritParams db_sql_exec_cancel
@@ -222,7 +222,7 @@ db_sql_exec_status <- function(
 #' `next_chunk_index` and `next_chunk_internal_link` fields for simple
 #' iteration through the result set.
 #'
-#' [Read more on Databricks API docs](https://docs.databricks.com/api/workspace/statementexecution/getstatementresultchunkn)
+#' [Read more on Databricks API docs](https://docs.databricks.com/api/aws/workspace/statementexecution/getstatementresultchunkn)
 #'
 #' @param chunk_index Integer, chunk index to fetch result. Starts from `0`.
 #' @inheritParams db_sql_exec_cancel

--- a/R/workspaces.R
+++ b/R/workspaces.R
@@ -69,7 +69,7 @@ db_workspace_delete <- function(
 #' At this time we do not support the `direct_download` parameter and returns a
 #' base64 encoded string.
 #'
-#' [See More](https://docs.databricks.com/api/workspace/workspace/export).
+#' [See More](https://docs.databricks.com/api/aws/workspace/workspace/export).
 #'
 #' @family Workspace API
 #'

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 `{brickster}` is the R toolkit for Databricks, it includes:
 
--   Wrappers for [Databricks API's](https://docs.databricks.com/api/workspace/introduction) (e.g. [`db_cluster_list`](https://databrickslabs.github.io/brickster/reference/db_cluster_list.html), [`db_volume_read`](https://databrickslabs.github.io/brickster/reference/db_volume_read.html))
+-   Wrappers for [Databricks API's](https://docs.databricks.com/api/aws/workspace/introduction) (e.g. [`db_cluster_list`](https://databrickslabs.github.io/brickster/reference/db_cluster_list.html), [`db_volume_read`](https://databrickslabs.github.io/brickster/reference/db_volume_read.html))
 
 -   Browser workspace assets via RStudio Connections Pane ([`open_workspace()`](https://databrickslabs.github.io/brickster/reference/open_workspace.html))
 
@@ -126,19 +126,19 @@ pak::pak("databrickslabs/brickster")
 
 | API | Available | Version |
 |----------------------------------|-------------------|-------------------|
-| [DBFS](https://docs.databricks.com/api/workspace/dbfs) | Yes | 2.0 |
-| [Secrets](https://docs.databricks.com/api/workspace/secrets) | Yes | 2.0 |
-| [Repos](https://docs.databricks.com/api/workspace/repos) | Yes | 2.0 |
-| [mlflow Model Registry](https://docs.databricks.com/api/workspace/modelregistry) | Yes | 2.0 |
-| [Clusters](https://docs.databricks.com/api/workspace/clusters) | Yes | 2.0 |
-| [Libraries](https://docs.databricks.com/api/workspace/libraries) | Yes | 2.0 |
-| [Workspace](https://docs.databricks.com/api/workspace/workspace) | Yes | 2.0 |
-| [Endpoints](https://docs.databricks.com/api/workspace/warehouses) | Yes | 2.0 |
-| [Query History](https://docs.databricks.com/api/workspace/queryhistory) | Yes | 2.0 |
-| [Jobs](https://docs.databricks.com/api/workspace/jobs) | Yes | 2.1 |
-| [Volumes (Files)](https://docs.databricks.com/api/workspace/files) | Yes | 2.0 |
-| [SQL Statement Execution](https://docs.databricks.com/api/workspace/statementexecution) | Yes | 2.0 |
-| [REST 1.2 Commands](https://docs.databricks.com/api/workspace/commandexecution) | Partially | 1.2 |
-| [Unity Catalog - Tables](https://docs.databricks.com/api/workspace/tables) | Yes | 2.1 |
-| [Unity Catalog - Volumes](https://docs.databricks.com/api/workspace/volumes) | Yes | 2.1 |
-| [Unity Catalog](https://docs.databricks.com/api/workspace/catalogs) | Partially | 2.1 |
+| [DBFS](https://docs.databricks.com/api/aws/workspace/dbfs) | Yes | 2.0 |
+| [Secrets](https://docs.databricks.com/api/aws/workspace/secrets) | Yes | 2.0 |
+| [Repos](https://docs.databricks.com/api/aws/workspace/repos) | Yes | 2.0 |
+| [mlflow Model Registry](https://docs.databricks.com/api/aws/workspace/modelregistry) | Yes | 2.0 |
+| [Clusters](https://docs.databricks.com/api/aws/workspace/clusters) | Yes | 2.0 |
+| [Libraries](https://docs.databricks.com/api/aws/workspace/libraries) | Yes | 2.0 |
+| [Workspace](https://docs.databricks.com/api/aws/workspace/workspace) | Yes | 2.0 |
+| [Endpoints](https://docs.databricks.com/api/aws/workspace/warehouses) | Yes | 2.0 |
+| [Query History](https://docs.databricks.com/api/aws/workspace/queryhistory) | Yes | 2.0 |
+| [Jobs](https://docs.databricks.com/api/aws/workspace/jobs) | Yes | 2.1 |
+| [Volumes (Files)](https://docs.databricks.com/api/aws/workspace/files) | Yes | 2.0 |
+| [SQL Statement Execution](https://docs.databricks.com/api/aws/workspace/statementexecution) | Yes | 2.0 |
+| [REST 1.2 Commands](https://docs.databricks.com/api/aws/workspace/commandexecution) | Partially | 1.2 |
+| [Unity Catalog - Tables](https://docs.databricks.com/api/aws/workspace/tables) | Yes | 2.1 |
+| [Unity Catalog - Volumes](https://docs.databricks.com/api/aws/workspace/volumes) | Yes | 2.1 |
+| [Unity Catalog](https://docs.databricks.com/api/aws/workspace/catalogs) | Partially | 2.1 |

--- a/man/db_cluster_create.Rd
+++ b/man/db_cluster_create.Rd
@@ -159,7 +159,7 @@ message.
 
 Cannot specify both \code{autoscale} and \code{num_workers}, must choose one.
 
-\href{https://docs.databricks.com/api/workspace/clusters/create}{More Documentation}.
+\href{https://docs.databricks.com/api/aws/workspace/clusters/create}{More Documentation}.
 }
 \seealso{
 Other Clusters API: 

--- a/man/db_cluster_events.Rd
+++ b/man/db_cluster_events.Rd
@@ -27,7 +27,7 @@ events starting from the beginning of time.}
 up to the current time.}
 
 \item{event_types}{List. Optional set of event types to filter by. Default
-is to return all events. \href{https://docs.databricks.com/api/workspace/clusters/events#events}{Event Types}.}
+is to return all events. \href{https://docs.databricks.com/api/aws/workspace/clusters/events#events}{Event Types}.}
 
 \item{order}{Either \code{DESC} (default) or \code{ASC}.}
 

--- a/man/db_jobs_create.Rd
+++ b/man/db_jobs_create.Rd
@@ -69,7 +69,7 @@ If \code{perform_request = TRUE}, returns endpoint-specific API output. If \code
 Create Job
 }
 \details{
-\href{https://docs.databricks.com/api/workspace/jobs/create}{Full Documentation}
+\href{https://docs.databricks.com/api/aws/workspace/jobs/create}{Full Documentation}
 }
 \seealso{
 \code{\link[=job_tasks]{job_tasks()}}, \code{\link[=job_task]{job_task()}}, \code{\link[=email_notifications]{email_notifications()}},

--- a/man/db_sql_exec_and_wait.Rd
+++ b/man/db_sql_exec_and_wait.Rd
@@ -39,7 +39,7 @@ A parameter consists of a name, a value, and \emph{optionally} a type.
 To represent a \code{NULL} value, the value field may be omitted or set to \code{NULL}
 explicitly.
 
-See \href{https://docs.databricks.com/api/workspace/statementexecution/executestatement}{docs}
+See \href{https://docs.databricks.com/api/aws/workspace/statementexecution/executestatement}{docs}
 for more details.}
 
 \item{row_limit}{Integer, applies the given row limit to the statement's
@@ -57,11 +57,11 @@ true. When using \code{EXTERNAL_LINKS} disposition, a default byte_limit of
 \item{wait_timeout}{Initial wait timeout (default "30s")}
 
 \item{disposition}{One of \code{"INLINE"} (default) or \code{"EXTERNAL_LINKS"}. See
-\href{https://docs.databricks.com/api/workspace/statementexecution/executestatement}{docs}
+\href{https://docs.databricks.com/api/aws/workspace/statementexecution/executestatement}{docs}
 for details.}
 
 \item{format}{One of \code{"JSON_ARRAY"} (default), \code{"ARROW_STREAM"}, or \code{"CSV"}.
-See \href{https://docs.databricks.com/api/workspace/statementexecution/executestatement}{docs}
+See \href{https://docs.databricks.com/api/aws/workspace/statementexecution/executestatement}{docs}
 for details.}
 
 \item{host}{Databricks workspace URL, defaults to calling \code{\link[=db_host]{db_host()}}.}

--- a/man/db_sql_exec_cancel.Rd
+++ b/man/db_sql_exec_cancel.Rd
@@ -31,7 +31,7 @@ Cancel SQL Query
 Requests that an executing statement be canceled. Callers must poll for
 status to see the terminal state.
 
-\href{https://docs.databricks.com/api/workspace/statementexecution/cancelexecution}{Read more on Databricks API docs}
+\href{https://docs.databricks.com/api/aws/workspace/statementexecution/cancelexecution}{Read more on Databricks API docs}
 }
 \seealso{
 Other SQL Execution APIs: 

--- a/man/db_sql_exec_query.Rd
+++ b/man/db_sql_exec_query.Rd
@@ -40,7 +40,7 @@ A parameter consists of a name, a value, and \emph{optionally} a type.
 To represent a \code{NULL} value, the value field may be omitted or set to \code{NULL}
 explicitly.
 
-See \href{https://docs.databricks.com/api/workspace/statementexecution/executestatement}{docs}
+See \href{https://docs.databricks.com/api/aws/workspace/statementexecution/executestatement}{docs}
 for more details.}
 
 \item{row_limit}{Integer, applies the given row limit to the statement's
@@ -56,11 +56,11 @@ true. When using \code{EXTERNAL_LINKS} disposition, a default byte_limit of
 100 GiB is applied if \code{byte_limit} is not explicitly set.}
 
 \item{disposition}{One of \code{"INLINE"} (default) or \code{"EXTERNAL_LINKS"}. See
-\href{https://docs.databricks.com/api/workspace/statementexecution/executestatement}{docs}
+\href{https://docs.databricks.com/api/aws/workspace/statementexecution/executestatement}{docs}
 for details.}
 
 \item{format}{One of \code{"JSON_ARRAY"} (default), \code{"ARROW_STREAM"}, or \code{"CSV"}.
-See \href{https://docs.databricks.com/api/workspace/statementexecution/executestatement}{docs}
+See \href{https://docs.databricks.com/api/aws/workspace/statementexecution/executestatement}{docs}
 for details.}
 
 \item{wait_timeout}{String, default is \code{"10s"}. The time in seconds the call
@@ -107,7 +107,7 @@ Execute SQL Query
 }
 \details{
 Refer to the
-\href{https://docs.databricks.com/api/workspace/statementexecution/executestatement}{web documentation}
+\href{https://docs.databricks.com/api/aws/workspace/statementexecution/executestatement}{web documentation}
 for detailed material on interaction of the various parameters and general recommendations
 }
 \seealso{

--- a/man/db_sql_exec_result.Rd
+++ b/man/db_sql_exec_result.Rd
@@ -43,7 +43,7 @@ in the \code{\link[=db_sql_exec_result]{db_sql_exec_result()}} request, and simi
 \code{next_chunk_index} and \code{next_chunk_internal_link} fields for simple
 iteration through the result set.
 
-\href{https://docs.databricks.com/api/workspace/statementexecution/getstatementresultchunkn}{Read more on Databricks API docs}
+\href{https://docs.databricks.com/api/aws/workspace/statementexecution/getstatementresultchunkn}{Read more on Databricks API docs}
 }
 \seealso{
 Other SQL Execution APIs: 

--- a/man/db_sql_exec_status.Rd
+++ b/man/db_sql_exec_status.Rd
@@ -38,7 +38,7 @@ When the statement is in the terminal states \code{CANCELED}, \code{CLOSED} or
 After at least 12 hours in terminal state, the statement is removed from the
 warehouse and further calls will receive an HTTP \code{404} response.
 
-\href{https://docs.databricks.com/api/workspace/statementexecution/getstatement}{Read more on Databricks API docs}
+\href{https://docs.databricks.com/api/aws/workspace/statementexecution/getstatement}{Read more on Databricks API docs}
 }
 \seealso{
 Other SQL Execution APIs: 

--- a/man/db_sql_query.Rd
+++ b/man/db_sql_query.Rd
@@ -41,7 +41,7 @@ A parameter consists of a name, a value, and \emph{optionally} a type.
 To represent a \code{NULL} value, the value field may be omitted or set to \code{NULL}
 explicitly.
 
-See \href{https://docs.databricks.com/api/workspace/statementexecution/executestatement}{docs}
+See \href{https://docs.databricks.com/api/aws/workspace/statementexecution/executestatement}{docs}
 for more details.}
 
 \item{row_limit}{Integer, applies the given row limit to the statement's

--- a/man/db_sql_query_history.Rd
+++ b/man/db_sql_query_history.Rd
@@ -47,7 +47,7 @@ db_sql_query_history(
 If \code{perform_request = TRUE}, returns endpoint-specific API output. If \code{FALSE}, returns an \code{httr2_request}.
 }
 \description{
-For more details refer to the \href{https://docs.databricks.com/api/workspace/queryhistory/list}{query history documentation}.
+For more details refer to the \href{https://docs.databricks.com/api/aws/workspace/queryhistory/list}{query history documentation}.
 This function elevates the sub-components of \code{filter_by} parameter to the R
 function directly.
 }

--- a/man/db_workspace_export.Rd
+++ b/man/db_workspace_export.Rd
@@ -49,7 +49,7 @@ API does not support exporting a library.
 At this time we do not support the \code{direct_download} parameter and returns a
 base64 encoded string.
 
-\href{https://docs.databricks.com/api/workspace/workspace/export}{See More}.
+\href{https://docs.databricks.com/api/aws/workspace/workspace/export}{See More}.
 }
 \seealso{
 Other Workspace API: 

--- a/vignettes/cluster-management.Rmd
+++ b/vignettes/cluster-management.Rmd
@@ -177,7 +177,7 @@ db_libs_cluster_status(cluster_id = new_cluster$cluster_id)
 
 ## Events
 
-A list of events regarding the clusters activity can be fetched via `db_cluster_events()`. There are many [event types](https://docs.databricks.com/api/workspace/clusters/events#events) that can occur, and by default the 50 most recent events are returned.
+A list of events regarding the clusters activity can be fetched via `db_cluster_events()`. There are many [event types](https://docs.databricks.com/api/aws/workspace/clusters/events#events) that can occur, and by default the 50 most recent events are returned.
 
 ```{r}
 events <- db_cluster_events(cluster_id = new_cluster$cluster_id)

--- a/vignettes/remote-repl.Rmd
+++ b/vignettes/remote-repl.Rmd
@@ -25,13 +25,13 @@ library(brickster)
 +==============================================================================================================+=======================+===============================================================================+
 | `db_sql_query`                                                                                               | SQL Warehouse         | Simple and efficient function to run SQL                                      |
 +--------------------------------------------------------------------------------------------------------------+-----------------------+-------------------------------------------------------------------------------+
-| [SQL execution API](https://docs.databricks.com/api/workspace/statementexecution)\                           | SQL Warehouse         | Lower level functions that align 1:1 with API endpoints                       |
+| [SQL execution API](https://docs.databricks.com/api/aws/workspace/statementexecution)\                           | SQL Warehouse         | Lower level functions that align 1:1 with API endpoints                       |
 | ([`db_sql_exec_*`](https://databrickslabs.github.io/brickster/reference/index.html#sql-statement-execution)) |                       |                                                                               |
 +--------------------------------------------------------------------------------------------------------------+-----------------------+-------------------------------------------------------------------------------+
 | Command execution context manager\                                                                           | Clusters\             | Higher level `R6` class for command execution contexts.                       |
 | (`db_context_manager`)                                                                                       | (Shared, Single User) |                                                                               |
 +--------------------------------------------------------------------------------------------------------------+-----------------------+-------------------------------------------------------------------------------+
-| [Command execution API](https://docs.databricks.com/api/workspace/commandexecution)\                         | Clusters\             | Lower level functions that align 1:1 with API endpoints                       |
+| [Command execution API](https://docs.databricks.com/api/aws/workspace/commandexecution)\                         | Clusters\             | Lower level functions that align 1:1 with API endpoints                       |
 | ([`db_context_*`](https://databrickslabs.github.io/brickster/reference/index.html#execution-contexts))       | (Shared, Single User) |                                                                               |
 +--------------------------------------------------------------------------------------------------------------+-----------------------+-------------------------------------------------------------------------------+
 | Databricks REPL\                                                                                             | Clusters\             | Supports all notebook languages, R is only supported on single user clusters. |
@@ -42,7 +42,7 @@ Databricks [REPL](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_
 
 # What is the Databricks REPL?
 
-The REPL temporarily connects the existing R console to a Databricks cluster (via [command execution APIs](https://docs.databricks.com/api/workspace/commandexecution)) and allows code in all supported languages to be sent interactively - as if it were running locally.
+The REPL temporarily connects the existing R console to a Databricks cluster (via [command execution APIs](https://docs.databricks.com/api/aws/workspace/commandexecution)) and allows code in all supported languages to be sent interactively - as if it were running locally.
 
 ## Getting Started
 

--- a/vignettes/sql-backend.Rmd
+++ b/vignettes/sql-backend.Rmd
@@ -30,7 +30,7 @@ Connecting to Databricks SQL Warehouses *typically* involves using one of the me
 |                                                                                         |                                                                               |                                                                      |
 |                                                                                         |                                                                               | Very slow with larger write operations.                              |
 +-----------------------------------------------------------------------------------------+-------------------------------------------------------------------------------+----------------------------------------------------------------------+
-| [Statement Execution API](https://docs.databricks.com/api/workspace/statementexecution) | Straightforward API that can handle data of all sizes.                        | No direct support for write operations.                              |
+| [Statement Execution API](https://docs.databricks.com/api/aws/workspace/statementexecution) | Straightforward API that can handle data of all sizes.                        | No direct support for write operations.                              |
 +-----------------------------------------------------------------------------------------+-------------------------------------------------------------------------------+----------------------------------------------------------------------+
 | Databricks SQL Connector\                                                               | Convenient to work with and good performance.                                 | It's in Python, requires `{reticulate}`.                             |
 | (`databricks-sql-connector`)                                                            |                                                                               |                                                                      |
@@ -50,7 +50,7 @@ That leaves a void for something that is:
 
 `{brickster}` now provides both `{DBI}` and `{dbplyr}` backends for working with Databricks SQL warehouses.
 
-It uses the [Statement Execution API](https://docs.databricks.com/api/workspace/statementexecution) in combination with the [Files API](https://docs.databricks.com/api/workspace/files) (the latter specifically for large data uploads).
+It uses the [Statement Execution API](https://docs.databricks.com/api/aws/workspace/statementexecution) in combination with the [Files API](https://docs.databricks.com/api/aws/workspace/files) (the latter specifically for large data uploads).
 
 ## Connecting to a Warehouse
 


### PR DESCRIPTION
## Summary

- Updates Databricks API reference links from `/api/workspace/...` to `/api/aws/workspace/...` in README, roxygen docs, generated Rd files, and vignettes.
- Adds a NEWS bullet for the documentation link update.

## Validation

- `devtools::document()`
- `git diff --check`

## Note

- Normal GET requests to these API reference routes return successfully. CRAN-style HEAD checks currently return 404 for these Databricks API reference routes, so this PR intentionally keeps link choice separate from the CRAN submission staging work.
