### PR TITLE
Ignore SECURITY.md in R builds

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,6 +9,7 @@
 ^\.covrignore$
 ^LICENSE\.md$
 ^NOTICE
+^SECURITY\.md$
 ^cran-comments\.md$
 ^CLAUDE.md
 ^\.claude


### PR DESCRIPTION
## Summary

- Adds `SECURITY.md` to `.Rbuildignore` so it is excluded from source package builds.
- Removes the CRAN NOTE about a non-standard top-level `SECURITY.md` file.

## Validation

- `R CMD build /tmp/brickster-security-rbuildignore`
- Verified the built tarball does not contain `SECURITY.md`.
