### PR TITLE
Run PR checks after approval

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -3,8 +3,8 @@
 on:
   push:
     branches: [main, master]
-  pull_request:
-    branches: [main, master]
+  pull_request_review:
+    types: [submitted]
 
 name: R-CMD-check
 
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   R-CMD-check-pr:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request_review' && github.event.review.state == 'approved'
     runs-on: ${{ matrix.config.os }}
 
     name: PR ${{ matrix.config.os }} (${{ matrix.config.r }})
@@ -33,6 +33,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: r-lib/actions/setup-pandoc@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2.12.0
 
@@ -53,7 +56,7 @@ jobs:
           GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
   R-CMD-check-pr-required:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request_review' && github.event.review.state == 'approved'
     needs: R-CMD-check-pr
     name: R-CMD-check-pr-required
     runs-on: ubuntu-24.04
@@ -62,7 +65,7 @@ jobs:
         run: echo "R CMD check PR matrix passed."
 
   R-CMD-check-pr-runtime:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request_review' && github.event.review.state == 'approved'
     environment: runtime
     runs-on: ${{ matrix.config.os }}
 
@@ -85,6 +88,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: r-lib/actions/setup-pandoc@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2.12.0
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -3,8 +3,8 @@
 on:
   push:
     branches: [main, master]
-  pull_request:
-    branches: [main, master]
+  pull_request_review:
+    types: [submitted]
 name: test-coverage.yaml
 
 permissions:
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   test-coverage:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request_review' && github.event.review.state == 'approved'
     runs-on: ubuntu-24.04
     env:
       NOT_CRAN: TRUE
@@ -21,6 +21,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: r-lib/actions/setup-r@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2.12.0
         with:
@@ -66,7 +68,7 @@ jobs:
           path: ${{ runner.temp }}/package
 
   test-coverage-pr-required:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request_review' && github.event.review.state == 'approved'
     needs: test-coverage
     name: test-coverage-pr-required
     runs-on: ubuntu-24.04
@@ -75,7 +77,7 @@ jobs:
         run: echo "Coverage PR job passed."
 
   test-coverage-pr-runtime:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request_review' && github.event.review.state == 'approved'
     environment: runtime
     runs-on: ubuntu-24.04
     env:
@@ -88,6 +90,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: r-lib/actions/setup-r@a51a8012b0aab7c32ef9d19bf54da93f3254335e # v2.12.0
         with:
@@ -169,7 +173,7 @@ jobs:
           path: ${{ runner.temp }}/package
 
   upload-coverage:
-    if: always() && !cancelled()
+    if: always() && !cancelled() && github.event_name == 'push'
     needs: [test-coverage, test-coverage-runtime]
     runs-on: ubuntu-24.04
     permissions:


### PR DESCRIPTION
## Summary

- Remove immediate `pull_request` triggers from R CMD check and coverage workflows.
- Run PR R CMD check and coverage jobs only after an approving `pull_request_review`.
- Keep PR runtime R CMD check and coverage jobs on approving review, preserving the protected `runtime` environment gate.
- Check out the reviewed PR head SHA for review-triggered jobs.

This prevents opening or updating a pull request from starting GitHub Actions. PR checks now wait for an approving review; pushes to `main`/`master` still run the existing runtime jobs.

## Validation

- Parsed all workflow YAML files with Ruby YAML.
- Ran `git diff --check`.
- Confirmed there are no remaining `pull_request` workflow triggers.
- `actionlint` was not installed locally.
