### PR TITLE
fix(connection-pane): remove correct Catalog node when Unity Catalog is inactive

### DIFF
--- a/R/connection-pane.R
+++ b/R/connection-pane.R
@@ -740,7 +740,7 @@ list_objects <- function(host, token,
   }
 
   if (!uc_active) {
-    info[["Data"]] <- NULL
+    info[["Catalog"]] <- NULL
   }
 
   data.frame(


### PR DESCRIPTION
I don't see a use for the "Data" entry believe it was left from a refactor.