### PR TITLE
[codex] Let pkgdown deploy without runtime approval

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -14,7 +14,6 @@ permissions:
 
 jobs:
   pkgdown:
-    environment: runtime
     permissions:
       contents: write # Deploy pkgdown output to the gh-pages branch.
     # This protected runner is acceptable only for privileged triggers above


### PR DESCRIPTION
## What changed

Removed `environment: runtime` from the `pkgdown` workflow job.

## Why

`pkgdown` deploys the static site using `GITHUB_TOKEN` and already only runs on privileged triggers: pushes to protected branches, release publication, or manual dispatch. It does not need Databricks runtime secrets, so it should not wait for runtime deployment review.

## Validation

- `git diff --check`
- Parsed `.github/workflows/pkgdown.yaml` with Ruby/Psych
- Repo pre-commit and pre-push secret scans passed

`actionlint` was not available locally.