### PR TITLE
Fix Unity Catalog list pagination metadata

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 -   Fixed Unity Catalog volume file requests so `db_volume_*` paths containing spaces are encoded correctly (#231)
 -   `db_cluster_events()` now forwards the `event_types` argument to the API, which was previously ignored
 -   `db_sql_warehouse_create()` and `db_sql_warehouse_edit()` now forward the `tags` argument to the API, which was previously ignored
+-   Unity Catalog list helpers now preserve `next_page_token` metadata in list responses for catalogs, schemas, tables, and volumes; their list arguments are sent as documented query parameters
 -   `db_uc_volumes_list()` now forwards the `max_results`, `include_browse`, and `page_token` arguments to the API, which were previously ignored
 -   `db_vs_indexes_query()` now sends the `score_threshold` argument to the API, which was previously ignored
 -   Added `show_progress` to `dbConnect()` for the DBI backend; `dbGetQuery()`, `dbFetch()`, `dbWriteTable()`, and dbplyr `collect()` now use the connection default while preserving per-call `show_progress` overrides (#223)

--- a/R/connection-pane.R
+++ b/R/connection-pane.R
@@ -33,7 +33,7 @@ readable_time <- function(x) {
 }
 
 get_catalogs <- function(host, token) {
-  catalogs <- db_uc_catalogs_list(host = host, token = token)
+  catalogs <- db_uc_catalogs_list(host = host, token = token)$catalogs
   if (length(catalogs) > 0) {
     data.frame(
       name = purrr::map_chr(catalogs, "name"),
@@ -50,7 +50,7 @@ get_schemas <- function(catalog, host, token) {
     catalog = catalog,
     host = host,
     token = token
-  )
+  )$schemas
   if (length(schemas) > 0) {
     data.frame(
       name = purrr::map_chr(schemas, "name"),
@@ -68,7 +68,7 @@ get_tables <- function(catalog, schema, host, token) {
     schema = schema,
     host = host,
     token = token
-  )
+  )$tables
   if (length(tables) > 0) {
     data.frame(
       name = purrr::map_chr(tables, "name"),
@@ -238,7 +238,7 @@ get_uc_volumes <- function(catalog, schema, host, token) {
     schema = schema,
     host = host,
     token = token
-  )
+  )$volumes
   if (length(volumes) > 0) {
     data.frame(
       name = purrr::map_chr(volumes, "name"),
@@ -256,7 +256,7 @@ get_uc_volume <- function(catalog, schema, host, volume, token) {
     schema = schema,
     host = host,
     token = token
-  )
+  )$volumes
 
   volume <- purrr::keep(volumes, \(x) x$name == volume)[[1]]
 
@@ -394,7 +394,7 @@ get_table_data <- function(catalog, schema, table, host, token, metadata = TRUE)
 }
 
 get_experiments <- function(host, token) {
-  experiments <- db_experiments_list(host = host, token = token)
+  experiments <- db_experiments_list(host = host, token = token)$experiments
   exp_names <- purrr::map_chr(experiments, "name")
   exp_ids <-  purrr::map_chr(experiments, "experiment_id")
   data.frame(

--- a/R/experiments.R
+++ b/R/experiments.R
@@ -22,7 +22,7 @@ db_experiments_list <- function(view_type = c("ACTIVE_ONLY", "DELETED_ONLY", "AL
   )
 
   if (perform_request) {
-    db_perform_request(req)$experiments
+    db_perform_request(req)
   } else {
     req
   }
@@ -63,4 +63,3 @@ db_experiments_get <- function(name = NULL, id = NULL,
     req
   }
 }
-

--- a/R/uc-catalogs.R
+++ b/R/uc-catalogs.R
@@ -9,7 +9,8 @@
 #'
 #' @family Unity Catalog Management
 #'
-#' @returns List
+#' @returns Full API response list, including `next_page_token` when present,
+#' or an `httr2_request` when `perform_request = FALSE`.
 #' @export
 db_uc_catalogs_list <- function(max_results = 1000,
                                 include_browse = TRUE,
@@ -19,23 +20,21 @@ db_uc_catalogs_list <- function(max_results = 1000,
 
   stopifnot(max_results <= 1000)
 
-  body <- list(
-    max_results = max_results,
-    include_browse = include_browse,
-    page_token = page_token
-  )
-
   req <- db_request(
     endpoint = "unity-catalog/catalogs",
     method = "GET",
     version = "2.1",
     host = host,
-    token = token,
-    body = body
-  )
+    token = token
+  ) |>
+    httr2::req_url_query(
+      max_results = max_results,
+      include_browse = from_logical(include_browse),
+      page_token = page_token
+    )
 
   if (perform_request) {
-    db_perform_request(req)$catalogs
+    db_perform_request(req)
   } else {
     req
   }

--- a/R/uc-schemas.R
+++ b/R/uc-schemas.R
@@ -8,7 +8,8 @@
 #'
 #' @family Unity Catalog Management
 #'
-#' @returns List
+#' @returns Full API response list, including `next_page_token` when present,
+#' or an `httr2_request` when `perform_request = FALSE`.
 #' @export
 db_uc_schemas_list <- function(catalog,
                                max_results = 1000,
@@ -18,23 +19,21 @@ db_uc_schemas_list <- function(catalog,
 
   stopifnot(max_results <= 1000)
 
-  body <- list(
-    max_results = max_results,
-    page_token = page_token
-  )
-
   req <- db_request(
     endpoint = "unity-catalog/schemas",
     method = "GET",
     version = "2.1",
     host = host,
-    token = token,
-    body = body
+    token = token
   ) |>
-    httr2::req_url_query(catalog_name = catalog)
+    httr2::req_url_query(
+      catalog_name = catalog,
+      max_results = max_results,
+      page_token = page_token
+    )
 
   if (perform_request) {
-    db_perform_request(req)$schemas
+    db_perform_request(req)
   } else {
     req
   }
@@ -78,4 +77,3 @@ db_uc_schemas_get <- function(catalog, schema,
     req
   }
 }
-

--- a/R/uc-tables.R
+++ b/R/uc-tables.R
@@ -21,7 +21,8 @@
 #'
 #' @family Unity Catalog Table Management
 #'
-#' @returns List
+#' @returns Full API response list, including `next_page_token` when present,
+#' or an `httr2_request` when `perform_request = FALSE`.
 #' @export
 db_uc_tables_list <- function(catalog, schema, max_results = 50,
                               omit_columns = TRUE,
@@ -47,6 +48,7 @@ db_uc_tables_list <- function(catalog, schema, max_results = 50,
       catalog_name = catalog,
       schema_name = schema,
       include_delta_metadata = from_logical(include_delta_metadata),
+      max_results = max_results,
       omit_columns = from_logical(omit_columns),
       omit_properties = from_logical(omit_properties),
       omit_username = from_logical(omit_username),
@@ -56,7 +58,7 @@ db_uc_tables_list <- function(catalog, schema, max_results = 50,
     )
 
   if (perform_request) {
-    db_perform_request(req)$tables
+    db_perform_request(req)
   } else {
     req
   }
@@ -228,4 +230,3 @@ db_uc_tables_summaries <- function(catalog,
     req
   }
 }
-

--- a/R/uc-volumes.R
+++ b/R/uc-volumes.R
@@ -11,7 +11,8 @@
 #'
 #' @family Unity Catalog Volume Management
 #'
-#' @returns List
+#' @returns Full API response list, including `next_page_token` when present,
+#' or an `httr2_request` when `perform_request = FALSE`.
 #' @export
 db_uc_volumes_list <- function(catalog, schema,
                                max_results = 10000,
@@ -36,7 +37,7 @@ db_uc_volumes_list <- function(catalog, schema,
     )
 
   if (perform_request) {
-    db_perform_request(req)$volumes
+    db_perform_request(req)
   } else {
     req
   }
@@ -212,6 +213,5 @@ db_uc_volumes_create <- function(catalog, schema, volume,
     req
   }
 }
-
 
 

--- a/man/db_uc_catalogs_list.Rd
+++ b/man/db_uc_catalogs_list.Rd
@@ -29,7 +29,8 @@ the principal can only access selective metadata for.}
 \code{FALSE} the httr2 request is returned \emph{without} being performed.}
 }
 \value{
-List
+Full API response list, including \code{next_page_token} when present,
+or an \code{httr2_request} when \code{perform_request = FALSE}.
 }
 \description{
 List Catalogs (Unity Catalog)

--- a/man/db_uc_schemas_list.Rd
+++ b/man/db_uc_schemas_list.Rd
@@ -28,7 +28,8 @@ db_uc_schemas_list(
 \code{FALSE} the httr2 request is returned \emph{without} being performed.}
 }
 \value{
-List
+Full API response list, including \code{next_page_token} when present,
+or an \code{httr2_request} when \code{perform_request = FALSE}.
 }
 \description{
 List Schemas (Unity Catalog)

--- a/man/db_uc_tables_list.Rd
+++ b/man/db_uc_tables_list.Rd
@@ -55,7 +55,8 @@ capabilities the table has.}
 \code{FALSE} the httr2 request is returned \emph{without} being performed.}
 }
 \value{
-List
+Full API response list, including \code{next_page_token} when present,
+or an \code{httr2_request} when \code{perform_request = FALSE}.
 }
 \description{
 List Tables (Unity Catalog)

--- a/man/db_uc_volumes_list.Rd
+++ b/man/db_uc_volumes_list.Rd
@@ -35,7 +35,8 @@ the principal can only access selective metadata for.}
 \code{FALSE} the httr2 request is returned \emph{without} being performed.}
 }
 \value{
-List
+Full API response list, including \code{next_page_token} when present,
+or an \code{httr2_request} when \code{perform_request = FALSE}.
 }
 \description{
 List Volumes (Unity Catalog)

--- a/tests/testthat/test-connection-pane-offline.R
+++ b/tests/testthat/test-connection-pane-offline.R
@@ -149,7 +149,9 @@ test_that("get_uc_model_versions applies aliases and returns per-version metadat
 test_that("catalog list helper returns stable typed frames for non-empty and empty inputs", {
   out_catalogs <- with_mocked_bindings(
     get_catalogs(host = "mock_host", token = "mock_token"),
-    db_uc_catalogs_list = function(...) list(list(name = "c1"), list(name = "c2")),
+    db_uc_catalogs_list = function(...) {
+      list(catalogs = list(list(name = "c1"), list(name = "c2")))
+    },
     .package = "brickster"
   )
 
@@ -158,12 +160,64 @@ test_that("catalog list helper returns stable typed frames for non-empty and emp
 
   out_catalogs_empty <- with_mocked_bindings(
     get_catalogs(host = "mock_host", token = "mock_token"),
-    db_uc_catalogs_list = function(...) list(),
+    db_uc_catalogs_list = function(...) list(catalogs = list()),
     .package = "brickster"
   )
 
   expect_identical(nrow(out_catalogs_empty), 0L)
   expect_s3_class(out_catalogs_empty, "data.frame")
+})
+
+test_that("table list helper reads tables from list response", {
+  out_tables <- with_mocked_bindings(
+    get_tables(
+      catalog = "main",
+      schema = "default",
+      host = "mock_host",
+      token = "mock_token"
+    ),
+    db_uc_tables_list = function(...) {
+      list(tables = list(list(name = "t1"), list(name = "t2")))
+    },
+    .package = "brickster"
+  )
+
+  expect_identical(out_tables$name, c("t1", "t2"))
+  expect_true(all(out_tables$type == "table"))
+})
+
+test_that("volume list helper reads volumes from list response", {
+  out_volumes <- with_mocked_bindings(
+    get_uc_volumes(
+      catalog = "main",
+      schema = "default",
+      host = "mock_host",
+      token = "mock_token"
+    ),
+    db_uc_volumes_list = function(...) {
+      list(volumes = list(list(name = "v1"), list(name = "v2")))
+    },
+    .package = "brickster"
+  )
+
+  expect_identical(out_volumes$name, c("v1", "v2"))
+  expect_true(all(out_volumes$type == "volume"))
+})
+
+test_that("experiment list helper reads experiments from list response", {
+  out_experiments <- with_mocked_bindings(
+    get_experiments(host = "mock_host", token = "mock_token"),
+    db_experiments_list = function(...) {
+      list(experiments = list(
+        list(name = "/Users/me/exp_one", experiment_id = "1"),
+        list(name = "/Shared/exp_two", experiment_id = "2")
+      ))
+    },
+    .package = "brickster"
+  )
+
+  expect_identical(out_experiments$name, c("exp_one (1)", "exp_two (2)"))
+  expect_true(all(out_experiments$type == "experiment"))
 })
 
 test_that("get_schema_objects summarizes only object groups that contain rows", {

--- a/tests/testthat/test-experiments.R
+++ b/tests/testthat/test-experiments.R
@@ -5,8 +5,13 @@ test_that("experiments API - don't perform", {
     "DATABRICKS_TOKEN" = "mock_token"
   ))
 
-  resp_list <- db_experiments_list(max_results = 1, perform_request = FALSE)
+  resp_list <- db_experiments_list(
+    max_results = 1,
+    page_token = "abc",
+    perform_request = FALSE
+  )
   expect_s3_class(resp_list, "httr2_request")
+  expect_identical(resp_list$body$data$page_token, "abc")
 
   resp_get_by_name <- db_experiments_get(
     name = "some name",
@@ -23,6 +28,27 @@ test_that("experiments API - don't perform", {
 
 })
 
+test_that("experiments API preserves pagination response metadata", {
+  withr::local_envvar(c(
+    "DATABRICKS_HOST" = "http://mock_host",
+    "DATABRICKS_TOKEN" = "mock_token"
+  ))
+
+  local_mocked_bindings(
+    db_perform_request = function(req, ...) {
+      list(
+        experiments = list(list(name = "some_experiment")),
+        next_page_token = "next-page"
+      )
+    }
+  )
+
+  resp_list <- db_experiments_list()
+
+  expect_identical(resp_list$experiments[[1]]$name, "some_experiment")
+  expect_identical(resp_list$next_page_token, "next-page")
+})
+
 skip_on_cran()
 skip_unless_authenticated()
 skip_unless_aws_workspace()
@@ -31,18 +57,18 @@ test_that("experiments API", {
 
   resp_list <- db_experiments_list(max_results = 1)
   expect_type(resp_list, "list")
-  expect_named(resp_list[[1]])
+  expect_named(resp_list$experiments[[1]])
 
-  resp_get_by_name <- db_experiments_get(name = resp_list[[1]]$name)
-  expect_equal(resp_list[[1]]$name, resp_get_by_name$name)
+  resp_get_by_name <- db_experiments_get(name = resp_list$experiments[[1]]$name)
+  expect_equal(resp_list$experiments[[1]]$name, resp_get_by_name$name)
 
-  resp_get_by_id <- db_experiments_get(id = resp_list[[1]]$experiment_id)
-  expect_equal(resp_list[[1]]$experiment_id, resp_get_by_name$experiment_id)
+  resp_get_by_id <- db_experiments_get(id = resp_list$experiments[[1]]$experiment_id)
+  expect_equal(resp_list$experiments[[1]]$experiment_id, resp_get_by_name$experiment_id)
 
   # don't allow both
   expect_error(db_experiments_get(
-    id = resp_list[[1]]$experiment_id,
-    name = resp_list[[1]]$name
+    id = resp_list$experiments[[1]]$experiment_id,
+    name = resp_list$experiments[[1]]$name
   ))
 
 })

--- a/tests/testthat/test-uc-catalogs.R
+++ b/tests/testthat/test-uc-catalogs.R
@@ -5,8 +5,17 @@ test_that("Unity Catalog: Catalogs API - don't perform", {
     "DATABRICKS_TOKEN" = "mock_token"
   ))
 
-  resp_catalog_list <- db_uc_catalogs_list(perform_request = FALSE)
+  resp_catalog_list <- db_uc_catalogs_list(
+    max_results = 50,
+    include_browse = FALSE,
+    page_token = "abc",
+    perform_request = FALSE
+  )
   expect_s3_class(resp_catalog_list, "httr2_request")
+  query <- httr2::url_parse(resp_catalog_list$url)$query
+  expect_identical(query$max_results, "50")
+  expect_identical(query$include_browse, "false")
+  expect_identical(query$page_token, "abc")
 
   resp_catalog_get <- db_uc_catalogs_get(
     catalog = "some_catalog",
@@ -14,6 +23,27 @@ test_that("Unity Catalog: Catalogs API - don't perform", {
   )
   expect_s3_class(resp_catalog_get, "httr2_request")
 
+})
+
+test_that("Unity Catalog: Catalogs API preserves pagination response metadata", {
+  withr::local_envvar(c(
+    "DATABRICKS_HOST" = "http://mock_host",
+    "DATABRICKS_TOKEN" = "mock_token"
+  ))
+
+  local_mocked_bindings(
+    db_perform_request = function(req, ...) {
+      list(
+        catalogs = list(list(name = "some_catalog")),
+        next_page_token = "next-page"
+      )
+    }
+  )
+
+  resp_catalog_list <- db_uc_catalogs_list()
+
+  expect_identical(resp_catalog_list$catalogs[[1]]$name, "some_catalog")
+  expect_identical(resp_catalog_list$next_page_token, "next-page")
 })
 
 skip_on_cran()
@@ -29,7 +59,7 @@ test_that("Unity Catalog: Catalogs API", {
 
   expect_no_error({
     resp_catalog_get <- db_uc_catalogs_get(
-      catalog = resp_catalog_list[[1]]$name
+      catalog = resp_catalog_list$catalogs[[1]]$name
     )
   })
 

--- a/tests/testthat/test-uc-schemas.R
+++ b/tests/testthat/test-uc-schemas.R
@@ -7,9 +7,15 @@ test_that("Unity Catalog: Schemas API - don't perform", {
 
   resp_schema_list <- db_uc_schemas_list(
     catalog = "some_catalog",
+    max_results = 50,
+    page_token = "abc",
     perform_request = FALSE
   )
   expect_s3_class(resp_schema_list, "httr2_request")
+  query <- httr2::url_parse(resp_schema_list$url)$query
+  expect_identical(query$catalog_name, "some_catalog")
+  expect_identical(query$max_results, "50")
+  expect_identical(query$page_token, "abc")
 
   resp_schema_get <- db_uc_schemas_get(
     catalog = "some_catalog",
@@ -18,6 +24,27 @@ test_that("Unity Catalog: Schemas API - don't perform", {
   )
   expect_s3_class(resp_schema_get, "httr2_request")
 
+})
+
+test_that("Unity Catalog: Schemas API preserves pagination response metadata", {
+  withr::local_envvar(c(
+    "DATABRICKS_HOST" = "http://mock_host",
+    "DATABRICKS_TOKEN" = "mock_token"
+  ))
+
+  local_mocked_bindings(
+    db_perform_request = function(req, ...) {
+      list(
+        schemas = list(list(name = "some_schema")),
+        next_page_token = "next-page"
+      )
+    }
+  )
+
+  resp_schema_list <- db_uc_schemas_list(catalog = "some_catalog")
+
+  expect_identical(resp_schema_list$schemas[[1]]$name, "some_schema")
+  expect_identical(resp_schema_list$next_page_token, "next-page")
 })
 
 skip_on_cran()
@@ -36,7 +63,7 @@ test_that("Unity Catalog: Schemas API", {
   expect_no_error({
     resp_schema_get <- db_uc_schemas_get(
       catalog = "main",
-      schema = resp_schema_list[[1]]$name
+      schema = resp_schema_list$schemas[[1]]$name
     )
   })
   expect_type(resp_schema_get, "list")

--- a/tests/testthat/test-uc-tables.R
+++ b/tests/testthat/test-uc-tables.R
@@ -15,9 +15,16 @@ test_that("Unity Catalog: Tables API - don't perform", {
   resp_tables_list <- db_uc_tables_list(
     catalog = "some_catalog",
     schema = "some_schema",
+    max_results = 10,
+    page_token = "abc",
     perform_request = FALSE
   )
   expect_s3_class(resp_tables_list, "httr2_request")
+  query <- httr2::url_parse(resp_tables_list$url)$query
+  expect_identical(query$catalog_name, "some_catalog")
+  expect_identical(query$schema_name, "some_schema")
+  expect_identical(query$max_results, "10")
+  expect_identical(query$page_token, "abc")
 
   resp_table_get <- db_uc_tables_get(
     catalog = "some_catalog",
@@ -43,6 +50,30 @@ test_that("Unity Catalog: Tables API - don't perform", {
   )
   expect_s3_class(resp_table_exists, "httr2_request")
 
+})
+
+test_that("Unity Catalog: Tables API preserves pagination response metadata", {
+  withr::local_envvar(c(
+    "DATABRICKS_HOST" = "http://mock_host",
+    "DATABRICKS_TOKEN" = "mock_token"
+  ))
+
+  local_mocked_bindings(
+    db_perform_request = function(req, ...) {
+      list(
+        tables = list(list(name = "some_table")),
+        next_page_token = "next-page"
+      )
+    }
+  )
+
+  resp_tables_list <- db_uc_tables_list(
+    catalog = "some_catalog",
+    schema = "some_schema"
+  )
+
+  expect_identical(resp_tables_list$tables[[1]]$name, "some_table")
+  expect_identical(resp_tables_list$next_page_token, "next-page")
 })
 
 skip_on_cran()

--- a/tests/testthat/test-uc-volumes.R
+++ b/tests/testthat/test-uc-volumes.R
@@ -8,9 +8,14 @@ test_that("Unity Catalog: Volumes API - don't perform", {
   resp_volumes_list <- db_uc_volumes_list(
     catalog = "some_catalog",
     schema = "some_schema",
+    page_token = "abc",
     perform_request = FALSE
   )
   expect_s3_class(resp_volumes_list, "httr2_request")
+  query <- httr2::url_parse(resp_volumes_list$url)$query
+  expect_identical(query$catalog_name, "some_catalog")
+  expect_identical(query$schema_name, "some_schema")
+  expect_identical(query$page_token, "abc")
 
   resp_volumes_get <- db_uc_volumes_get(
     catalog = "some_catalog",
@@ -58,6 +63,30 @@ test_that("Unity Catalog: Volumes API - don't perform", {
 
 })
 
+test_that("Unity Catalog: Volumes API preserves pagination response metadata", {
+  withr::local_envvar(c(
+    "DATABRICKS_HOST" = "http://mock_host",
+    "DATABRICKS_TOKEN" = "mock_token"
+  ))
+
+  local_mocked_bindings(
+    db_perform_request = function(req, ...) {
+      list(
+        volumes = list(list(name = "some_volume")),
+        next_page_token = "next-page"
+      )
+    }
+  )
+
+  resp_volumes_list <- db_uc_volumes_list(
+    catalog = "some_catalog",
+    schema = "some_schema"
+  )
+
+  expect_identical(resp_volumes_list$volumes[[1]]$name, "some_volume")
+  expect_identical(resp_volumes_list$next_page_token, "next-page")
+})
+
 skip_on_cran()
 skip_unless_authenticated()
 skip_unless_aws_workspace()
@@ -71,9 +100,9 @@ test_that("Unity Catalog: Volumes API", {
 
   expect_no_error({
     resp_volumes_get <- db_uc_volumes_get(
-      catalog = resp_volumes_list[[1]]$catalog_name,
-      schema = resp_volumes_list[[1]]$schema_name,
-      volume = resp_volumes_list[[1]]$name
+      catalog = resp_volumes_list$volumes[[1]]$catalog_name,
+      schema = resp_volumes_list$volumes[[1]]$schema_name,
+      volume = resp_volumes_list$volumes[[1]]$name
     )
   })
 

--- a/tests/testthat/test-unity-catalog.R
+++ b/tests/testthat/test-unity-catalog.R
@@ -124,7 +124,7 @@ test_that("Unity Catalog API", {
 
   expect_no_error({
     resp_catalog_get <- db_uc_catalogs_get(
-      catalog = resp_catalog_list[[1]]$name
+      catalog = resp_catalog_list$catalogs[[1]]$name
     )
   })
   expect_type(resp_catalog_get, "list")
@@ -139,7 +139,7 @@ test_that("Unity Catalog API", {
   expect_no_error({
     resp_schema_get <- db_uc_schemas_get(
       catalog = "main",
-      schema = resp_schema_list[[1]]$name
+      schema = resp_schema_list$schemas[[1]]$name
     )
   })
   expect_type(resp_schema_get, "list")

--- a/vignettes/working-with-volumes.Rmd
+++ b/vignettes/working-with-volumes.Rmd
@@ -143,7 +143,7 @@ Use `db_uc_volumes_*` when you need to create or manage the **volume object itse
 
 | Operation | Function | Notes |
 |-----------|----------|-------|
-| List volumes in schema | `db_uc_volumes_list()` | Returns volumes under `<catalog>.<schema>` |
+| List volumes in schema | `db_uc_volumes_list()` | Returns a response with volumes under `<catalog>.<schema>` |
 | Get one volume | `db_uc_volumes_get()` | Returns metadata for one volume |
 | Create volume | `db_uc_volumes_create()` | Supports `MANAGED` and `EXTERNAL` |
 | Update volume metadata | `db_uc_volumes_update()` | Rename/comment/owner updates |


### PR DESCRIPTION
## Summary
- Update Unity Catalog list helpers for catalogs, schemas, tables, and volumes to return the full list response body so callers can access `next_page_token` and request the next page themselves.
- Send Unity Catalog list arguments as documented query parameters; this also adds the missing `max_results` query parameter for `db_uc_tables_list()`.
- Update connection pane internals and tests to read catalog/schema/table/volume items from the nested response fields.
- Preserve pagination metadata from the internal `db_experiments_list()` helper and update its connection-pane consumer.
- Clarify docs/NEWS without claiming the old GET body parameters were ignored.

## Related
- Follows the investigation from #241. That PR was closed because live testing showed the existing GET body parameters were not ignored, but it surfaced that list wrappers were dropping `next_page_token` by returning only nested item arrays.

## Validation
- `devtools::document()` was run. This local environment has roxygen2 7.1.2 while the package was last documented with 7.3.2, so unrelated generated Rd ordering churn was restored and only the affected man pages are included.
- `testthat::test_local(filter = "uc-(tables|volumes)|experiments|connection-pane-offline", stop_on_failure = TRUE)` -> 54 pass, 3 live-workspace skips
- `testthat::test_local(stop_on_failure = TRUE)` -> 980 pass, 21 live-workspace skips
- `git diff --check`