### PR TITLE
Support Databricks CLI authentication and early token refresh

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
     dplyr,
     fs,
     glue,
-    httr2 (>= 1.1.1),
+    httr2 (>= 1.3.0),
     ini,
     jsonlite,
     lifecycle,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,6 +30,7 @@ Imports:
     lifecycle,
     methods,
     nanoarrow,
+    processx,
     purrr,
     R6,
     rlang,

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 -   Fixed OAuth U2M and M2M authentication across multiple Databricks workspaces in one R session by isolating OAuth clients and cached tokens per workspace (#255)
 -   Added `databricks-cli` authentication support for profiles created by `databricks auth login`; `{brickster}` obtains tokens through `databricks auth token`, caches only the short-lived access token in memory, and leaves durable credentials and refresh to the CLI (#253)
+-   Authentication mode overrides now come from `auth_type` in the selected `.databrickscfg` profile; replace `DATABRICKS_AUTH_TYPE` with the profile field. Environment-only authentication continues to infer the mode from available credentials.
 -   Fixed `dbWriteTable()` and `dbAppendTable()` standard-path writes for binary columns, which now use Databricks `BINARY` types and `X'...'` literals when no staging volume is configured (#245)
 -   `dbConnect()` now preserves Databricks API error details when its validation query fails
 -   `db_perform_request()` and `db_perform_response()` now preserve useful error messages when Databricks returns non-JSON error bodies such as empty, plain-text, or HTML responses (#242)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # brickster (development version)
 
 -   Fixed OAuth U2M and M2M authentication across multiple Databricks workspaces in one R session by isolating OAuth clients and cached tokens per workspace (#255)
+-   OAuth tokens are now refreshed 40 seconds before expiry, avoiding Databricks API rejections during the final 30 seconds of a token's lifetime; this requires `{httr2}` 1.3.0 or later (#257)
 -   Added `databricks-cli` authentication support for profiles created by `databricks auth login`; `{brickster}` obtains tokens through `databricks auth token`, caches only the short-lived access token in memory, and leaves durable credentials and refresh to the CLI (#253)
 -   Authentication mode overrides now come from `auth_type` in the selected `.databrickscfg` profile; replace `DATABRICKS_AUTH_TYPE` with the profile field. Environment-only authentication continues to infer the mode from available credentials.
 -   Fixed `dbWriteTable()` and `dbAppendTable()` standard-path writes for binary columns, which now use Databricks `BINARY` types and `X'...'` literals when no staging volume is configured (#245)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # brickster (development version)
 
 -   Fixed OAuth U2M and M2M authentication across multiple Databricks workspaces in one R session by isolating OAuth clients and cached tokens per workspace (#255)
+-   Added `databricks-cli` authentication support for profiles created by `databricks auth login`; `{brickster}` obtains tokens through `databricks auth token`, caches only the short-lived access token in memory, and leaves durable credentials and refresh to the CLI (#253)
 -   Fixed `dbWriteTable()` and `dbAppendTable()` standard-path writes for binary columns, which now use Databricks `BINARY` types and `X'...'` literals when no staging volume is configured (#245)
 -   `dbConnect()` now preserves Databricks API error details when its validation query fails
 -   `db_perform_request()` and `db_perform_response()` now preserve useful error messages when Databricks returns non-JSON error bodies such as empty, plain-text, or HTML responses (#242)

--- a/R/package-auth.R
+++ b/R/package-auth.R
@@ -143,6 +143,15 @@ db_read_netrc <- function(path = "~/.netrc") {
 #'
 NULL
 
+databricks_config_path <- function() {
+  config_path <- Sys.getenv("DATABRICKS_CONFIG_FILE")
+  if (!nzchar(config_path)) {
+    config_path <- fs::path_home(".databrickscfg")
+  }
+
+  fs::path_real(config_path)
+}
+
 
 #' Reads Databricks CLI Config
 #' @details Reads `.databrickscfg` file and retrieves the values associated to
@@ -179,16 +188,7 @@ read_databrickscfg <- function(
     profile <- "DEFAULT"
   }
 
-  home_dir <- fs::path_home()
-
-  # use the .databrickscfg location specified in DATABRICKS_CONFIG_FILE
-  databricks_config_file <- Sys.getenv("DATABRICKS_CONFIG_FILE")
-  if (!nzchar(databricks_config_file)) {
-    config_path <- fs::path(home_dir, ".databrickscfg")
-  } else {
-    config_path <- databricks_config_file
-  }
-  config_path <- fs::path_real(config_path)
+  config_path <- databricks_config_path()
 
   # read config file (ini format) and fetch values from specified profile
   vars <- ini::read.ini(config_path)[[profile]]
@@ -708,18 +708,28 @@ db_oauth_client <- function(
 }
 
 #' Returns the default config profile
-#' @details Returns the config profile first looking at `DATABRICKS_CONFIG_PROFILE`
-#' and then the `db_profile` option.
+#' @details Returns the config profile first looking at `DATABRICKS_CONFIG_PROFILE`,
+#' then the `db_profile` option, and then the CLI-selected default profile.
 #'
 #' @returns profile name
 #' @keywords internal
 default_config_profile <- function() {
   profile <- Sys.getenv("DATABRICKS_CONFIG_PROFILE")
   if (nzchar(profile)) {
-    profile
-  } else {
-    getOption("db_profile")
+    return(profile)
   }
+
+  profile <- getOption("db_profile")
+  if (!is.null(profile)) {
+    return(profile)
+  }
+
+  if (!use_databricks_cfg()) {
+    return(NULL)
+  }
+
+  settings <- ini::read.ini(databricks_config_path())[["__settings__"]]
+  settings[["default_profile"]]
 }
 
 #' Returns whether or not to use a `.databrickscfg` file

--- a/R/package-auth.R
+++ b/R/package-auth.R
@@ -533,7 +533,8 @@ db_req_auth_databricks_cli <- function(
       get = function() db_cli_token_cache[[key]],
       set = function(token) db_cli_token_cache[[key]] <- token,
       clear = function() db_cli_token_cache[[key]] <- NULL
-    )
+    ),
+    expiry_margin = 40
   )
 }
 

--- a/R/package-auth.R
+++ b/R/package-auth.R
@@ -508,15 +508,10 @@ db_cli_token <- function(
   tryCatch(
     {
       token <- jsonlite::fromJSON(output)
-      expiry <- as.POSIXct(
-        token$expiry,
-        format = "%Y-%m-%dT%H:%M:%OSZ",
-        tz = "UTC"
-      )
       httr2::oauth_token(
         access_token = token$access_token,
         token_type = token$token_type,
-        expires_in = floor(as.numeric(expiry) - as.numeric(Sys.time()))
+        expires_in = token$expires_in
       )
     },
     error = function(cnd) {

--- a/R/package-auth.R
+++ b/R/package-auth.R
@@ -383,6 +383,7 @@ db_auth_type <- function(profile = default_config_profile()) {
     profile = profile,
     error = FALSE
   )
+  from_env <- !is.null(auth_type)
 
   if (is.null(auth_type) && use_databricks_cfg()) {
     auth_type <- read_databrickscfg(
@@ -396,7 +397,15 @@ db_auth_type <- function(profile = default_config_profile()) {
     return(NULL)
   }
 
-  tolower(gsub("_", "-", auth_type, fixed = TRUE))
+  auth_type <- tolower(gsub("_", "-", auth_type, fixed = TRUE))
+  if (from_env && identical(auth_type, "databricks-cli")) {
+    cli::cli_abort(c(
+      "CLI authentication cannot be selected with an environment auth type:",
+      "i" = "Use {.val databricks-cli} in the selected {.file .databrickscfg} profile."
+    ))
+  }
+
+  auth_type
 }
 
 resolve_oauth_auth_mode <- function(

--- a/R/package-auth.R
+++ b/R/package-auth.R
@@ -228,8 +228,7 @@ auth_env_key <- function(
     "client_secret",
     "azure_client_id",
     "azure_client_secret",
-    "azure_tenant_id",
-    "auth_type"
+    "azure_tenant_id"
   )
 ) {
   key <- match.arg(key)
@@ -243,8 +242,7 @@ auth_env_key <- function(
     client_secret = "DATABRICKS_CLIENT_SECRET",
     azure_client_id = "ARM_CLIENT_ID",
     azure_client_secret = "ARM_CLIENT_SECRET",
-    azure_tenant_id = "ARM_TENANT_ID",
-    auth_type = "DATABRICKS_AUTH_TYPE"
+    azure_tenant_id = "ARM_TENANT_ID"
   )
 }
 
@@ -253,7 +251,7 @@ auth_env_key <- function(
 #'
 #' @param key The value to fetch from profile. One of `token`, `host`, `wsid`,
 #' `client_id`, `client_secret`, `azure_client_id`, `azure_client_secret`,
-#' `azure_tenant_id`, or `auth_type`
+#' or `azure_tenant_id`
 #' @param profile Character, the name of the profile to retrieve values
 #' @param error Boolean, when key isn't found should error be raised
 #'
@@ -268,8 +266,7 @@ read_env_var <- function(
     "client_secret",
     "azure_client_id",
     "azure_client_secret",
-    "azure_tenant_id",
-    "auth_type"
+    "azure_tenant_id"
   ),
   profile = NULL,
   error = TRUE
@@ -378,34 +375,20 @@ db_azure_tenant_id <- function(profile = default_config_profile()) {
 }
 
 db_auth_type <- function(profile = default_config_profile()) {
-  auth_type <- read_env_var(
+  if (!use_databricks_cfg()) {
+    return(NULL)
+  }
+
+  auth_type <- read_databrickscfg(
     key = "auth_type",
     profile = profile,
     error = FALSE
   )
-  from_env <- !is.null(auth_type)
-
-  if (is.null(auth_type) && use_databricks_cfg()) {
-    auth_type <- read_databrickscfg(
-      key = "auth_type",
-      profile = profile,
-      error = FALSE
-    )
-  }
-
   if (is.null(auth_type) || !nzchar(auth_type)) {
     return(NULL)
   }
 
-  auth_type <- tolower(gsub("_", "-", auth_type, fixed = TRUE))
-  if (from_env && identical(auth_type, "databricks-cli")) {
-    cli::cli_abort(c(
-      "CLI authentication cannot be selected with an environment auth type:",
-      "i" = "Use {.val databricks-cli} in the selected {.file .databrickscfg} profile."
-    ))
-  }
-
-  auth_type
+  tolower(gsub("_", "-", auth_type, fixed = TRUE))
 }
 
 resolve_oauth_auth_mode <- function(
@@ -418,7 +401,7 @@ resolve_oauth_auth_mode <- function(
     if (identical(auth_type, "oauth-m2m")) {
       if (!has_db_m2m) {
         cli::cli_abort(c(
-          "{.var DATABRICKS_AUTH_TYPE} was set to {.val oauth-m2m} but Databricks M2M credentials are incomplete:",
+          "Authentication type {.val oauth-m2m} requires Databricks M2M credentials:",
           "x" = "Need both {.var DATABRICKS_CLIENT_ID} and {.var DATABRICKS_CLIENT_SECRET}."
         ))
       }
@@ -428,7 +411,7 @@ resolve_oauth_auth_mode <- function(
     if (identical(auth_type, "azure-client-secret")) {
       if (!has_azure_m2m) {
         cli::cli_abort(c(
-          "{.var DATABRICKS_AUTH_TYPE} was set to {.val azure-client-secret} but Azure service principal credentials are incomplete:",
+          "Authentication type {.val azure-client-secret} requires Azure service principal credentials:",
           "x" = "Need {.var ARM_CLIENT_ID}, {.var ARM_CLIENT_SECRET}, and {.var ARM_TENANT_ID}."
         ))
       }
@@ -653,7 +636,8 @@ build_databricks_u2m_oauth_client <- function(host) {
 #' @param azure_client_id Azure AD service principal application id.
 #' @param azure_client_secret Azure AD service principal client secret.
 #' @param azure_tenant_id Azure AD tenant id.
-#' @param auth_type Optional explicit auth mode override from `DATABRICKS_AUTH_TYPE`.
+#' @param auth_type Optional auth mode. Defaults to `auth_type` from the selected
+#'   `.databrickscfg` profile.
 #'
 #' @details
 #' With no explicit `auth_type`, the default order is Databricks OAuth M2M, then

--- a/R/package-auth.R
+++ b/R/package-auth.R
@@ -1,5 +1,15 @@
 # internal package functions for authentication
 
+db_host_url <- function(host) {
+  if (!grepl("://", host, fixed = TRUE)) {
+    host <- paste0("https://", host)
+  }
+
+  host <- httr2::url_parse(host)
+  host$scheme <- "https"
+  host
+}
+
 #' Generate/Fetch Databricks Host
 #'
 #' @description
@@ -44,21 +54,7 @@ db_host <- function(
     } else {
       host <- read_env_var(key = "host", profile = profile)
     }
-    parsed_url <- httr2::url_parse(host)
-
-    # inject scheme if not present then re-build with https
-    if (is.null(parsed_url$scheme)) {
-      parsed_url$scheme <- "https"
-    }
-
-    # if hostname is missing change path to host
-    if (is.null(parsed_url$hostname)) {
-      parsed_url$hostname <- parsed_url$path
-      parsed_url$path <- NULL
-    }
-
-    host <- httr2::url_build(parsed_url)
-    host <- httr2::url_parse(host)$hostname
+    host <- db_host_url(host)$hostname
   } else {
     # otherwise construct host string
     host <- paste0(prefix, id, ".cloud.databricks.com")
@@ -388,7 +384,7 @@ db_auth_type <- function(profile = default_config_profile()) {
     error = FALSE
   )
 
-  if ((is.null(auth_type) || !nzchar(auth_type)) && use_databricks_cfg()) {
+  if (is.null(auth_type) && use_databricks_cfg()) {
     auth_type <- read_databrickscfg(
       key = "auth_type",
       profile = profile,
@@ -400,24 +396,7 @@ db_auth_type <- function(profile = default_config_profile()) {
     return(NULL)
   }
 
-  tolower(auth_type)
-}
-
-normalize_oauth_auth_type <- function(auth_type = NULL) {
-  if (is.null(auth_type) || !nzchar(auth_type)) {
-    return(NULL)
-  }
-
-  normalized <- tolower(gsub("_", "-", auth_type, fixed = TRUE))
-
-  if (normalized %in% c("oauth-m2m", "azure-client-secret", "oauth-u2m")) {
-    return(normalized)
-  }
-
-  cli::cli_abort(c(
-    "Invalid {.var DATABRICKS_AUTH_TYPE} value {.val {auth_type}}:",
-    "x" = "Supported values are {.val oauth-m2m}, {.val azure-client-secret}, or {.val oauth-u2m}."
-  ))
+  tolower(gsub("_", "-", auth_type, fixed = TRUE))
 }
 
 resolve_oauth_auth_mode <- function(
@@ -447,7 +426,17 @@ resolve_oauth_auth_mode <- function(
       return("azure-client-secret")
     }
 
-    return("oauth-u2m")
+    if (identical(auth_type, "oauth-u2m")) {
+      return("oauth-u2m")
+    }
+
+    cli::cli_abort(c(
+      "Authentication type {.val {auth_type}} cannot be used by the OAuth client:",
+      "x" = paste0(
+        "Supported values for OAuth are {.val oauth-m2m}, ",
+        "{.val azure-client-secret}, or {.val oauth-u2m}."
+      )
+    ))
   }
 
   # default auth order when override is not set
@@ -478,6 +467,87 @@ db_oauth_client_cache_name <- function(
   )
 
   paste0("brickster-", auth_mode, "-", rlang::hash(cache_context))
+}
+
+db_cli_token_cache <- new.env(parent = emptyenv())
+
+db_cli_token <- function(
+  host,
+  profile = NULL,
+  cli_path = Sys.getenv("DATABRICKS_CLI_PATH", unset = "databricks")
+) {
+  target <- if (!is.null(profile) && nzchar(profile)) {
+    c("--profile", profile)
+  } else {
+    c("--host", httr2::url_build(db_host_url(host)))
+  }
+  args <- c("auth", "token", target)
+  output <- tryCatch(
+    processx::run(
+      command = cli_path,
+      args = args,
+      timeout = 60000,
+      windows_hide_window = TRUE
+    )$stdout,
+    error = function(cnd) {
+      detail <- trimws(cnd$stderr %||% conditionMessage(cnd))
+      login_command <- paste(
+        c("databricks", "auth", "login", args[3:4]),
+        collapse = " "
+      )
+      cli::cli_abort(
+        c(
+          "Failed to obtain an OAuth token from the Databricks CLI.",
+          "x" = detail,
+          "i" = "Run {.code {login_command}} and try again."
+        )
+      )
+    }
+  )
+
+  tryCatch(
+    {
+      token <- jsonlite::fromJSON(output)
+      expiry <- as.POSIXct(
+        token$expiry,
+        format = "%Y-%m-%dT%H:%M:%OSZ",
+        tz = "UTC"
+      )
+      httr2::oauth_token(
+        access_token = token$access_token,
+        token_type = token$token_type,
+        expires_in = floor(as.numeric(expiry) - as.numeric(Sys.time()))
+      )
+    },
+    error = function(cnd) {
+      cli::cli_abort(
+        "The Databricks CLI returned a malformed OAuth token response."
+      )
+    }
+  )
+}
+
+db_req_auth_databricks_cli <- function(
+  req,
+  host,
+  profile = default_config_profile()
+) {
+  key <- rlang::hash(list(
+    config_file = Sys.getenv("DATABRICKS_CONFIG_FILE"),
+    profile = profile,
+    host = tolower(host)
+  ))
+
+  httr2::req_oauth(
+    req = req,
+    flow = db_cli_token,
+    flow_params = list(host = host, profile = profile),
+    cache = list(
+      get = function() db_cli_token_cache[[key]],
+      set = function(token) db_cli_token_cache[[key]] <- token,
+      clear = function() db_cli_token_cache[[key]] <- NULL
+    )
+  )
 }
 
 build_databricks_m2m_oauth_client <- function(host, client_id, client_secret) {
@@ -598,6 +668,12 @@ db_oauth_client <- function(
   azure_tenant_id = db_azure_tenant_id(),
   auth_type = db_auth_type()
 ) {
+  if (is.null(auth_type) || !nzchar(auth_type)) {
+    auth_type <- NULL
+  } else {
+    auth_type <- tolower(gsub("_", "-", auth_type, fixed = TRUE))
+  }
+
   has_db_m2m <- !is.null(client_id) &&
     nzchar(client_id) &&
     !is.null(client_secret) &&
@@ -611,7 +687,7 @@ db_oauth_client <- function(
     nzchar(azure_tenant_id)
 
   auth_mode <- resolve_oauth_auth_mode(
-    auth_type = normalize_oauth_auth_type(auth_type),
+    auth_type = auth_type,
     has_db_m2m = has_db_m2m,
     has_azure_m2m = has_azure_m2m
   )

--- a/R/request-helpers.R
+++ b/R/request-helpers.R
@@ -62,7 +62,8 @@ db_request <- function(
           req,
           client = oauth_client$client,
           scope = oauth_client$scope,
-          token_params = oauth_client$token_params
+          token_params = oauth_client$token_params,
+          expiry_margin = 40
         )
       } else if (!is_hosted_session() && rlang::is_interactive()) {
         # use client to auth
@@ -71,7 +72,8 @@ db_request <- function(
           client = oauth_client$client,
           scope = oauth_client$scope,
           auth_url = oauth_client$auth_url,
-          redirect_uri = "http://localhost:8020"
+          redirect_uri = "http://localhost:8020",
+          expiry_margin = 40
         )
       } else {
         cli::cli_abort("cannot find token or initiate OAuth flow")

--- a/R/request-helpers.R
+++ b/R/request-helpers.R
@@ -43,30 +43,39 @@ db_request <- function(
     httr2::req_retry(max_tries = 3, backoff = ~2, retry_on_failure = TRUE)
 
   # if token is present use directly
-  # otherwise initiate OAuth 2.0 U2M or M2M Workspace flow
+  # otherwise resolve the configured credential provider
   if (!is.null(token)) {
     req <- httr2::req_auth_bearer_token(req = req, token = token)
   } else {
-    oauth_client <- db_oauth_client(host = host)
+    auth_type <- db_auth_type()
 
-    if (oauth_client$is_m2m) {
-      req <- httr2::req_oauth_client_credentials(
-        req,
-        client = oauth_client$client,
-        scope = oauth_client$scope,
-        token_params = oauth_client$token_params
-      )
-    } else if (!is_hosted_session() && rlang::is_interactive()) {
-      # use client to auth
-      req <- httr2::req_oauth_auth_code(
-        req,
-        client = oauth_client$client,
-        scope = oauth_client$scope,
-        auth_url = oauth_client$auth_url,
-        redirect_uri = "http://localhost:8020"
-      )
+    if (identical(auth_type, "databricks-cli")) {
+      req <- db_req_auth_databricks_cli(req = req, host = host)
     } else {
-      cli::cli_abort("cannot find token or initiate OAuth flow")
+      oauth_client <- db_oauth_client(
+        host = host,
+        auth_type = auth_type
+      )
+
+      if (oauth_client$is_m2m) {
+        req <- httr2::req_oauth_client_credentials(
+          req,
+          client = oauth_client$client,
+          scope = oauth_client$scope,
+          token_params = oauth_client$token_params
+        )
+      } else if (!is_hosted_session() && rlang::is_interactive()) {
+        # use client to auth
+        req <- httr2::req_oauth_auth_code(
+          req,
+          client = oauth_client$client,
+          scope = oauth_client$scope,
+          auth_url = oauth_client$auth_url,
+          redirect_uri = "http://localhost:8020"
+        )
+      } else {
+        cli::cli_abort("cannot find token or initiate OAuth flow")
+      }
     }
   }
 

--- a/man/db_oauth_client.Rd
+++ b/man/db_oauth_client.Rd
@@ -27,7 +27,8 @@ db_oauth_client(
 
 \item{azure_tenant_id}{Azure AD tenant id.}
 
-\item{auth_type}{Optional explicit auth mode override from \code{DATABRICKS_AUTH_TYPE}.}
+\item{auth_type}{Optional auth mode. Defaults to \code{auth_type} from the selected
+\code{.databrickscfg} profile.}
 }
 \value{
 List containing \code{client} (\code{\link[httr2:oauth_client]{httr2::oauth_client()}}), \code{auth_url},

--- a/man/default_config_profile.Rd
+++ b/man/default_config_profile.Rd
@@ -13,7 +13,7 @@ profile name
 Returns the default config profile
 }
 \details{
-Returns the config profile first looking at \code{DATABRICKS_CONFIG_PROFILE}
-and then the \code{db_profile} option.
+Returns the config profile first looking at \code{DATABRICKS_CONFIG_PROFILE},
+then the \code{db_profile} option, and then the CLI-selected default profile.
 }
 \keyword{internal}

--- a/man/read_env_var.Rd
+++ b/man/read_env_var.Rd
@@ -6,7 +6,7 @@
 \usage{
 read_env_var(
   key = c("token", "host", "wsid", "client_id", "client_secret", "azure_client_id",
-    "azure_client_secret", "azure_tenant_id", "auth_type"),
+    "azure_client_secret", "azure_tenant_id"),
   profile = NULL,
   error = TRUE
 )
@@ -14,7 +14,7 @@ read_env_var(
 \arguments{
 \item{key}{The value to fetch from profile. One of \code{token}, \code{host}, \code{wsid},
 \code{client_id}, \code{client_secret}, \code{azure_client_id}, \code{azure_client_secret},
-\code{azure_tenant_id}, or \code{auth_type}}
+or \code{azure_tenant_id}}
 
 \item{profile}{Character, the name of the profile to retrieve values}
 

--- a/tests/testthat/test-auth-offline-helpers.R
+++ b/tests/testthat/test-auth-offline-helpers.R
@@ -56,9 +56,19 @@ local_sign_cli_request <- function(req) {
 
 test_that("configured auth types are normalized before provider routing", {
   local_clear_cli_auth()
-  withr::local_envvar(DATABRICKS_AUTH_TYPE = "databricks_cli")
+  withr::local_envvar(DATABRICKS_AUTH_TYPE = "oauth_m2m")
 
-  expect_identical(db_auth_type(), "databricks-cli")
+  expect_identical(db_auth_type(), "oauth-m2m")
+})
+
+test_that("Databricks CLI auth cannot be selected from the environment", {
+  local_clear_cli_auth()
+  withr::local_envvar(DATABRICKS_AUTH_TYPE = "databricks-cli")
+
+  expect_error(
+    db_auth_type(),
+    "cannot be selected with an environment auth type"
+  )
 })
 
 test_that("OAuth auth resolution rejects non-OAuth providers", {

--- a/tests/testthat/test-auth-offline-helpers.R
+++ b/tests/testthat/test-auth-offline-helpers.R
@@ -95,14 +95,19 @@ test_that("CLI token responses are parsed without exposing refresh credentials",
 
   token <- db_cli_token(
     host = "workspace.example.com",
-    profile = "DEV",
+    profile = NULL,
     cli_path = "/mock/databricks"
   )
 
   expect_identical(state$command, "/mock/databricks")
   expect_identical(
     state$args,
-    c("auth", "token", "--profile", "DEV")
+    c(
+      "auth",
+      "token",
+      "--host",
+      "https://workspace.example.com/"
+    )
   )
   expect_identical(token$access_token, "cli-access-token")
   expect_identical(token$token_type, "Bearer")
@@ -230,17 +235,18 @@ test_that("Databricks CLI auth is deferred and cached until expiry", {
   config_file <- fs::path(config_dir, "databricks.cfg")
   writeLines(
     c(
-      "[DEFAULT]",
+      "[WORKSPACE]",
       "host = https://workspace.example.com",
       "auth_type = databricks-cli",
       "[__settings__]",
       "auth_storage = secure",
-      "default_profile = DEFAULT"
+      "default_profile = WORKSPACE"
     ),
     config_file
   )
   withr::local_envvar(DATABRICKS_CONFIG_FILE = config_file)
   withr::local_options(use_databrickscfg = TRUE)
+  expect_identical(default_config_profile(), "WORKSPACE")
 
   local_mocked_bindings(
     run = function(command, args, ...) {
@@ -272,8 +278,8 @@ test_that("Databricks CLI auth is deferred and cached until expiry", {
     c(
       "auth",
       "token",
-      "--host",
-      "https://workspace.example.com/"
+      "--profile",
+      "WORKSPACE"
     )
   )
 

--- a/tests/testthat/test-auth-offline-helpers.R
+++ b/tests/testthat/test-auth-offline-helpers.R
@@ -1,0 +1,308 @@
+local_clear_cli_auth <- function() {
+  withr::local_envvar(
+    c(
+      DATABRICKS_AUTH_TYPE = NA_character_,
+      DATABRICKS_CLI_PATH = NA_character_,
+      DATABRICKS_CONFIG_FILE = NA_character_,
+      DATABRICKS_CONFIG_PROFILE = NA_character_,
+      DATABRICKS_CLIENT_ID = NA_character_,
+      DATABRICKS_CLIENT_SECRET = NA_character_,
+      ARM_CLIENT_ID = NA_character_,
+      ARM_CLIENT_SECRET = NA_character_,
+      ARM_TENANT_ID = NA_character_
+    ),
+    .local_envir = parent.frame()
+  )
+  withr::local_options(
+    use_databrickscfg = FALSE,
+    db_profile = NULL,
+    .local_envir = parent.frame()
+  )
+  rlang::env_unbind(
+    db_cli_token_cache,
+    rlang::env_names(db_cli_token_cache)
+  )
+  withr::defer(
+    rlang::env_unbind(
+      db_cli_token_cache,
+      rlang::env_names(db_cli_token_cache)
+    ),
+    envir = parent.frame()
+  )
+}
+
+local_cli_token_json <- function(expires_in = 3600) {
+  jsonlite::toJSON(
+    list(
+      access_token = "cli-access-token",
+      token_type = "Bearer",
+      expiry = format(
+        Sys.time() + expires_in,
+        "%Y-%m-%dT%H:%M:%SZ",
+        tz = "UTC"
+      )
+    ),
+    auto_unbox = TRUE
+  )
+}
+
+local_sign_cli_request <- function(req) {
+  policy <- req$policies$auth_sign
+  do.call(
+    policy$fun,
+    c(
+      list(req = req, cache = policy$cache),
+      policy$params
+    )
+  )
+}
+
+test_that("configured auth types are normalized before provider routing", {
+  local_clear_cli_auth()
+  withr::local_envvar(DATABRICKS_AUTH_TYPE = "databricks_cli")
+
+  expect_identical(db_auth_type(), "databricks-cli")
+})
+
+test_that("OAuth auth resolution rejects non-OAuth providers", {
+  local_clear_cli_auth()
+
+  expect_error(
+    resolve_oauth_auth_mode(
+      auth_type = "databricks-cli",
+      has_db_m2m = FALSE,
+      has_azure_m2m = FALSE
+    ),
+    "cannot be used by the OAuth client"
+  )
+})
+
+test_that("CLI token responses are parsed without exposing refresh credentials", {
+  local_clear_cli_auth()
+  state <- new.env(parent = emptyenv())
+  state$command <- NULL
+  state$args <- NULL
+
+  local_mocked_bindings(
+    run = function(command, args, ...) {
+      state$command <- command
+      state$args <- args
+      list(
+        status = 0L,
+        stdout = local_cli_token_json(),
+        stderr = ""
+      )
+    },
+    .package = "processx"
+  )
+
+  token <- db_cli_token(
+    host = "workspace.example.com",
+    profile = "DEV",
+    cli_path = "/mock/databricks"
+  )
+
+  expect_identical(state$command, "/mock/databricks")
+  expect_identical(
+    state$args,
+    c("auth", "token", "--profile", "DEV")
+  )
+  expect_identical(token$access_token, "cli-access-token")
+  expect_identical(token$token_type, "Bearer")
+  expect_s3_class(token, "httr2_token")
+  expect_gt(token$expires_at, as.numeric(Sys.time()))
+  expect_null(token$refresh_token)
+})
+
+test_that("CLI command failures are actionable", {
+  local_clear_cli_auth()
+
+  local_mocked_bindings(
+    run = function(command, args, ...) {
+      error <- simpleError("Databricks CLI failed")
+      error$stderr <- "profile is not logged in"
+      stop(error)
+    },
+    .package = "processx"
+  )
+
+  error <- tryCatch(
+    db_cli_token(
+      host = "workspace.example.com",
+      profile = "DEV",
+      cli_path = "/mock/databricks"
+    ),
+    error = identity
+  )
+
+  expect_s3_class(error, "error")
+  expect_match(conditionMessage(error), "profile is not logged in")
+})
+
+test_that("CLI execution failures retain their cause", {
+  local_clear_cli_auth()
+
+  local_mocked_bindings(
+    run = function(command, args, ...) {
+      stop("process timed out")
+    },
+    .package = "processx"
+  )
+
+  expect_error(
+    db_cli_token(
+      host = "workspace.example.com",
+      profile = "DEV",
+      cli_path = "/mock/databricks"
+    ),
+    regexp = "process timed out"
+  )
+})
+
+test_that("malformed CLI responses do not expose stdout", {
+  local_clear_cli_auth()
+
+  local_mocked_bindings(
+    run = function(command, args, ...) {
+      list(
+        status = 0L,
+        stdout = "malformed-must-not-leak",
+        stderr = ""
+      )
+    },
+    .package = "processx"
+  )
+
+  error <- tryCatch(
+    db_cli_token(
+      host = "workspace.example.com",
+      profile = "DEV",
+      cli_path = "/mock/databricks"
+    ),
+    error = identity
+  )
+
+  expect_s3_class(error, "error")
+  expect_match(conditionMessage(error), "malformed")
+  expect_false(grepl(
+    "malformed-must-not-leak",
+    conditionMessage(error),
+    fixed = TRUE
+  ))
+})
+
+test_that("invalid CLI expiry metadata is rejected", {
+  local_clear_cli_auth()
+
+  local_mocked_bindings(
+    run = function(command, args, ...) {
+      list(
+        status = 0L,
+        stdout = jsonlite::toJSON(
+          list(
+            access_token = "cli-access-token",
+            token_type = "Bearer",
+            expiry = "not-a-timestamp"
+          ),
+          auto_unbox = TRUE
+        ),
+        stderr = ""
+      )
+    },
+    .package = "processx"
+  )
+
+  expect_error(
+    db_cli_token(
+      host = "workspace.example.com",
+      profile = "DEV",
+      cli_path = "/mock/databricks"
+    ),
+    "malformed"
+  )
+})
+
+test_that("Databricks CLI auth is deferred and cached until expiry", {
+  local_clear_cli_auth()
+  state <- new.env(parent = emptyenv())
+  state$calls <- 0L
+  state$args <- NULL
+
+  config_dir <- withr::local_tempdir()
+  config_file <- fs::path(config_dir, "databricks.cfg")
+  writeLines(
+    c(
+      "[DEFAULT]",
+      "host = https://workspace.example.com",
+      "auth_type = databricks-cli",
+      "[__settings__]",
+      "auth_storage = secure",
+      "default_profile = DEFAULT"
+    ),
+    config_file
+  )
+  withr::local_envvar(DATABRICKS_CONFIG_FILE = config_file)
+  withr::local_options(use_databrickscfg = TRUE)
+
+  local_mocked_bindings(
+    run = function(command, args, ...) {
+      state$calls <- state$calls + 1L
+      state$args <- args
+      list(
+        status = 0L,
+        stdout = local_cli_token_json(),
+        stderr = ""
+      )
+    },
+    .package = "processx"
+  )
+
+  req <- db_request(
+    endpoint = "clusters/list",
+    method = "GET",
+    version = "2.0",
+    host = "workspace.example.com",
+    token = NULL
+  )
+
+  expect_s3_class(req, "httr2_request")
+  expect_identical(state$calls, 0L)
+  expect_s3_class(local_sign_cli_request(req), "httr2_request")
+  expect_identical(state$calls, 1L)
+  expect_identical(
+    state$args,
+    c(
+      "auth",
+      "token",
+      "--host",
+      "https://workspace.example.com/"
+    )
+  )
+
+  req_two <- db_request(
+    endpoint = "warehouses/list",
+    method = "GET",
+    version = "2.0",
+    host = "workspace.example.com",
+    token = NULL
+  )
+  expect_s3_class(local_sign_cli_request(req_two), "httr2_request")
+  expect_identical(state$calls, 1L)
+
+  req_two$policies$auth_sign$cache$set(httr2::oauth_token(
+    access_token = "expired",
+    expires_in = -1
+  ))
+  expect_s3_class(local_sign_cli_request(req_two), "httr2_request")
+  expect_identical(state$calls, 2L)
+
+  req_other <- db_request(
+    endpoint = "warehouses/list",
+    method = "GET",
+    version = "2.0",
+    host = "other-workspace.example.com",
+    token = NULL
+  )
+  expect_s3_class(local_sign_cli_request(req_other), "httr2_request")
+  expect_identical(state$calls, 3L)
+})

--- a/tests/testthat/test-auth-offline-helpers.R
+++ b/tests/testthat/test-auth-offline-helpers.R
@@ -1,7 +1,6 @@
 local_clear_cli_auth <- function() {
   withr::local_envvar(
     c(
-      DATABRICKS_AUTH_TYPE = NA_character_,
       DATABRICKS_CLI_PATH = NA_character_,
       DATABRICKS_CONFIG_FILE = NA_character_,
       DATABRICKS_CONFIG_PROFILE = NA_character_,
@@ -56,19 +55,19 @@ local_sign_cli_request <- function(req) {
 
 test_that("configured auth types are normalized before provider routing", {
   local_clear_cli_auth()
-  withr::local_envvar(DATABRICKS_AUTH_TYPE = "oauth_m2m")
+
+  config_file <- fs::path(withr::local_tempdir(), "databricks.cfg")
+  writeLines(
+    c(
+      "[DEFAULT]",
+      "auth_type = oauth_m2m"
+    ),
+    config_file
+  )
+  withr::local_envvar(DATABRICKS_CONFIG_FILE = config_file)
+  withr::local_options(use_databrickscfg = TRUE)
 
   expect_identical(db_auth_type(), "oauth-m2m")
-})
-
-test_that("Databricks CLI auth cannot be selected from the environment", {
-  local_clear_cli_auth()
-  withr::local_envvar(DATABRICKS_AUTH_TYPE = "databricks-cli")
-
-  expect_error(
-    db_auth_type(),
-    "cannot be selected with an environment auth type"
-  )
 })
 
 test_that("OAuth auth resolution rejects non-OAuth providers", {

--- a/tests/testthat/test-auth-offline-helpers.R
+++ b/tests/testthat/test-auth-offline-helpers.R
@@ -36,11 +36,8 @@ local_cli_token_json <- function(expires_in = 3600) {
     list(
       access_token = "cli-access-token",
       token_type = "Bearer",
-      expiry = format(
-        Sys.time() + expires_in,
-        "%Y-%m-%dT%H:%M:%SZ",
-        tz = "UTC"
-      )
+      expiry = "2026-07-14T12:11:01.79814+10:00",
+      expires_in = expires_in
     ),
     auto_unbox = TRUE
   )
@@ -191,7 +188,7 @@ test_that("malformed CLI responses do not expose stdout", {
   ))
 })
 
-test_that("invalid CLI expiry metadata is rejected", {
+test_that("invalid CLI expires_in metadata is rejected", {
   local_clear_cli_auth()
 
   local_mocked_bindings(
@@ -202,7 +199,8 @@ test_that("invalid CLI expiry metadata is rejected", {
           list(
             access_token = "cli-access-token",
             token_type = "Bearer",
-            expiry = "not-a-timestamp"
+            expiry = "2026-07-14T12:11:01.79814+10:00",
+            expires_in = "not-a-number"
           ),
           auto_unbox = TRUE
         ),

--- a/tests/testthat/test-auth-offline-helpers.R
+++ b/tests/testthat/test-auth-offline-helpers.R
@@ -279,6 +279,7 @@ test_that("Databricks CLI auth is deferred and cached until expiry", {
   )
 
   expect_s3_class(req, "httr2_request")
+  expect_identical(req$policies$auth_sign$params$expiry_margin, 40)
   expect_identical(state$calls, 0L)
   expect_s3_class(local_sign_cli_request(req), "httr2_request")
   expect_identical(state$calls, 1L)
@@ -303,8 +304,8 @@ test_that("Databricks CLI auth is deferred and cached until expiry", {
   expect_identical(state$calls, 1L)
 
   req_two$policies$auth_sign$cache$set(httr2::oauth_token(
-    access_token = "expired",
-    expires_in = -1
+    access_token = "expiring",
+    expires_in = 35
   ))
   expect_s3_class(local_sign_cli_request(req_two), "httr2_request")
   expect_identical(state$calls, 2L)

--- a/tests/testthat/test-auth.R
+++ b/tests/testthat/test-auth.R
@@ -1,12 +1,14 @@
 local_clear_auth_env <- function() {
-  withr::local_envvar(c(
-    DATABRICKS_AUTH_TYPE = NA_character_,
-    DATABRICKS_CONFIG_FILE = NA_character_,
-    DATABRICKS_CONFIG_PROFILE = NA_character_,
-    ARM_CLIENT_ID = NA_character_,
-    ARM_CLIENT_SECRET = NA_character_,
-    ARM_TENANT_ID = NA_character_
-  ), .local_envir = parent.frame())
+  withr::local_envvar(
+    c(
+      DATABRICKS_CONFIG_FILE = NA_character_,
+      DATABRICKS_CONFIG_PROFILE = NA_character_,
+      ARM_CLIENT_ID = NA_character_,
+      ARM_CLIENT_SECRET = NA_character_,
+      ARM_TENANT_ID = NA_character_
+    ),
+    .local_envir = parent.frame()
+  )
   withr::local_options(
     use_databrickscfg = FALSE,
     db_profile = NULL,
@@ -272,8 +274,7 @@ test_that("auth functions - azure m2m credentials from env", {
   withr::local_envvar(
     ARM_CLIENT_ID = "azure-client-id",
     ARM_CLIENT_SECRET = "azure-client-secret",
-    ARM_TENANT_ID = "azure-tenant-id",
-    DATABRICKS_AUTH_TYPE = "azure-client-secret"
+    ARM_TENANT_ID = "azure-tenant-id"
   )
 
   client <- db_oauth_client(
@@ -352,7 +353,7 @@ test_that("auth functions - default fallback selects azure m2m before u2m", {
   expect_identical(client$auth_mode, "azure-client-secret")
 })
 
-test_that("auth functions - auth type ordering and override", {
+test_that("auth functions - auth type ordering and explicit override", {
   local_clear_auth_env()
 
   withr::local_envvar(
@@ -367,8 +368,10 @@ test_that("auth functions - auth type ordering and override", {
   expect_identical(default_client$auth_mode, "oauth-m2m")
   expect_identical(default_client$client$id, "dbx-client-id")
 
-  withr::local_envvar(DATABRICKS_AUTH_TYPE = "azure-client-secret")
-  azure_client <- db_oauth_client(host = "some-host")
+  azure_client <- db_oauth_client(
+    host = "some-host",
+    auth_type = "azure-client-secret"
+  )
   expect_identical(azure_client$auth_mode, "azure-client-secret")
   expect_identical(azure_client$client$id, "azure-client-id")
 })
@@ -379,12 +382,11 @@ test_that("auth functions - auth type override requires matching credentials", {
   withr::local_envvar(
     ARM_CLIENT_ID = "azure-client-id",
     ARM_CLIENT_SECRET = "azure-client-secret",
-    ARM_TENANT_ID = "azure-tenant-id",
-    DATABRICKS_AUTH_TYPE = "oauth-m2m"
+    ARM_TENANT_ID = "azure-tenant-id"
   )
 
   expect_error(
-    db_oauth_client(host = "some-host"),
+    db_oauth_client(host = "some-host", auth_type = "oauth-m2m"),
     "DATABRICKS_CLIENT_ID"
   )
 })
@@ -392,39 +394,15 @@ test_that("auth functions - auth type override requires matching credentials", {
 test_that("auth functions - invalid auth type errors", {
   local_clear_auth_env()
 
-  withr::local_envvar(DATABRICKS_AUTH_TYPE = "not-real")
   expect_error(
-    db_oauth_client(host = "some-host", client_id = NULL, client_secret = NULL),
+    db_oauth_client(
+      host = "some-host",
+      client_id = NULL,
+      client_secret = NULL,
+      auth_type = "not-real"
+    ),
     "Supported values"
   )
-})
-
-test_that("auth functions - env auth type overrides .databrickscfg auth type", {
-  local_clear_auth_env()
-
-  withr::local_options(use_databrickscfg = TRUE)
-  withr::local_envvar(
-    DATABRICKS_CONFIG_FILE = "databricks.cfg",
-    DATABRICKS_AUTH_TYPE = "oauth-u2m",
-    DATABRICKS_CLIENT_ID = "dbx-client-id",
-    DATABRICKS_CLIENT_SECRET = "dbx-client-secret",
-    ARM_CLIENT_ID = "azure-client-id",
-    ARM_CLIENT_SECRET = "azure-client-secret",
-    ARM_TENANT_ID = "azure-tenant-id"
-  )
-  withr::local_file("databricks.cfg", {
-    writeLines(
-      c(
-        '[DEFAULT]',
-        'host = http://some-host',
-        'auth_type = azure-client-secret'
-      ),
-      "databricks.cfg"
-    )
-  })
-
-  client <- db_oauth_client(host = "some-host")
-  expect_identical(client$auth_mode, "oauth-u2m")
 })
 
 test_that("auth functions - host handling", {

--- a/tests/testthat/test-databricks-dbi-offline-helpers.R
+++ b/tests/testthat/test-databricks-dbi-offline-helpers.R
@@ -125,6 +125,31 @@ test_that("dbConnect preserves validation query error details", {
   )
 })
 
+test_that("dbConnect keeps dynamic CLI authentication refreshable", {
+  drv <- DatabricksSQL()
+  state <- new.env(parent = emptyenv())
+  state$validation_token <- "not-called"
+
+  local_mocked_bindings(
+    db_sql_query = function(..., token) {
+      state$validation_token <- token
+      data.frame(test_connection = 1)
+    },
+    dbi_connection_opened = function(conn) invisible(TRUE),
+    .package = "brickster"
+  )
+
+  con <- dbConnect(
+    drv,
+    warehouse_id = "wh-1",
+    host = "workspace.example.com",
+    token = NULL
+  )
+
+  expect_null(state$validation_token)
+  expect_null(con@token)
+})
+
 test_that("dbWriteTable validates user input", {
   con <- make_dbi_test_con(staging_volume = "/Volumes/c/s/v")
   value <- data.frame(x = 1:3)

--- a/tests/testthat/test-request-helpers.R
+++ b/tests/testthat/test-request-helpers.R
@@ -1,12 +1,14 @@
 local_clear_auth_env <- function() {
-  withr::local_envvar(c(
-    DATABRICKS_AUTH_TYPE = NA_character_,
-    DATABRICKS_CONFIG_FILE = NA_character_,
-    DATABRICKS_CONFIG_PROFILE = NA_character_,
-    ARM_CLIENT_ID = NA_character_,
-    ARM_CLIENT_SECRET = NA_character_,
-    ARM_TENANT_ID = NA_character_
-  ), .local_envir = parent.frame())
+  withr::local_envvar(
+    c(
+      DATABRICKS_CONFIG_FILE = NA_character_,
+      DATABRICKS_CONFIG_PROFILE = NA_character_,
+      ARM_CLIENT_ID = NA_character_,
+      ARM_CLIENT_SECRET = NA_character_,
+      ARM_TENANT_ID = NA_character_
+    ),
+    .local_envir = parent.frame()
+  )
   withr::local_options(
     use_databrickscfg = FALSE,
     db_profile = NULL,
@@ -14,7 +16,11 @@ local_clear_auth_env <- function() {
   )
 }
 
-local_error_response <- function(body, content_type = "application/json", status = 400) {
+local_error_response <- function(
+  body,
+  content_type = "application/json",
+  status = 400
+) {
   httr2::response(
     status_code = status,
     headers = list("content-type" = content_type),

--- a/tests/testthat/test-request-helpers.R
+++ b/tests/testthat/test-request-helpers.R
@@ -137,6 +137,37 @@ test_that("request helpers - m2m auth flow", {
     req$policies$auth_sign$params$flow_params$client$id,
     "client-id"
   )
+  expect_identical(req$policies$auth_sign$params$expiry_margin, 40)
+})
+
+test_that("request helpers - u2m auth flow", {
+  local_clear_auth_env()
+  withr::local_envvar(c(
+    DATABRICKS_CLIENT_ID = NA_character_,
+    DATABRICKS_CLIENT_SECRET = NA_character_
+  ))
+  local_mocked_bindings(
+    is_hosted_session = function() FALSE,
+    .package = "brickster"
+  )
+  local_mocked_bindings(
+    is_interactive = function() TRUE,
+    .package = "rlang"
+  )
+
+  req <- db_request(
+    endpoint = "clusters/list",
+    method = "GET",
+    version = "2.0",
+    host = "workspace.example.com",
+    token = NULL
+  )
+
+  expect_identical(
+    req$policies$auth_sign$params$flow,
+    "oauth_flow_auth_code"
+  )
+  expect_identical(req$policies$auth_sign$params$expiry_margin, 40)
 })
 
 test_that("request helpers isolate OAuth clients and tokens by workspace", {

--- a/vignettes/setup-auth.Rmd
+++ b/vignettes/setup-auth.Rmd
@@ -155,17 +155,17 @@ This behaviour works when using credentials specified in either `.Renviron` or `
 
 ```{r}
 # using .Renviron
-db_host() # returns `DATABRICKS_HOST`
+db_host() # returns `DATABRICKS_HOST` (.Renviron)
 
 # switch profile to 'prod'
 options(db_profile = "prod")
-db_host() # returns `DATABRICKS_HOST_PROD`
+db_host() # returns `DATABRICKS_HOST_PROD` (.Renviron)
 
 # clear the session-specific profile selection
 options(db_profile = NULL)
 # use .databrickscfg
 options(use_databrickscfg = TRUE)
-db_host() # returns the CLI-selected default, otherwise `DEFAULT`
+db_host() # returns the CLI-selected default, otherwise `DEFAULT` (.databrickscfg)
 
 options(db_profile = "prod")
 db_host() # returns host from `prod` profile (.databrickscfg)

--- a/vignettes/setup-auth.Rmd
+++ b/vignettes/setup-auth.Rmd
@@ -19,7 +19,7 @@ knitr::opts_chunk$set(
 
 The `{brickster}` package connects to a Databricks workspace in three ways:
 
-1.  [OAuth user-to-machine (U2M) authentication](https://docs.databricks.com/en/dev-tools/auth/oauth-u2m.html#oauth-user-to-machine-u2m-authentication)
+1.  [OAuth user-to-machine (U2M) authentication](https://docs.databricks.com/en/dev-tools/auth/oauth-u2m.html#oauth-user-to-machine-u2m-authentication), either directly or through credentials managed by the Databricks CLI
 2.  [OAuth machine-to-machine (M2M) authentication](https://docs.databricks.com/en/dev-tools/auth/oauth-m2m.html)
 3.  [Personal Access Tokens (PAT)](https://docs.databricks.com/en/dev-tools/auth/pat.html)
 
@@ -47,7 +47,7 @@ To get started add the following to your `.Renviron`:
 
 -   `ARM_TENANT_ID`: Azure AD tenant id (*only required for Azure service principal OAuth M2M*)
 
--   `DATABRICKS_AUTH_TYPE`: Optional auth mode override (`oauth-m2m`, `azure-client-secret`, `oauth-u2m`)
+-   `DATABRICKS_AUTH_TYPE`: Optional auth mode override (`oauth-m2m`, `azure-client-secret`, `oauth-u2m`, `databricks-cli`)
 
 -   `DATABRICKS_WSID`: The workspace ID ([docs](https://docs.databricks.com/workspace/workspace-details.html#workspace-instance-names-urls-and-ids))
 
@@ -112,22 +112,38 @@ There are two methods that `{brickster}` supports to simplify switching of crede
 1.  Adding multiple credentials to `.Renviron`, each additional set of credentials is differentiated via a suffix (e.g. `DATABRICKS_TOKEN_DEV`)
 2.  Using a `.databrickscfg` file (primary method in [Databricks CLI](https://docs.databricks.com/dev-tools/cli/index.html#set-up-authentication))
 
-To differentiate between (1) and (2) the option `use_databrickscfg` is used, the following example shows how to switch the session to use `.databrickscfg`.
+The `use_databrickscfg` option selects which configuration source `{brickster}`
+reads. It does not sign in to the Databricks CLI or select a named profile.
+The following example switches the session from `.Renviron` to
+`.databrickscfg`:
 
 ```{r}
-# will use the `DEFAULT` profile in `.databrickscfg`
+# uses the CLI-selected default profile, or `DEFAULT` when none is selected
 options(use_databrickscfg = TRUE)
 
-# values returned should be those in profile of `.databrickscfg`
+# values are read from `.databrickscfg`
 db_host()
 db_token()
 ```
 
-The default behaviour is to read credentials from `.Renviron`. If you wish to change this it's recommended to set the option within `.Rprofile` so that it's set during initialization of the R session.
+With its default value of `FALSE`, `{brickster}` does not discover profiles
+created by `databricks auth login`. Set the option in `.Rprofile` when
+`.databrickscfg` should be the normal configuration source. Posit Workbench
+managed OAuth sessions enable `.databrickscfg` automatically.
 
 ### Switching Between Credentials
 
-The `db_profile` option controls which profiles credentials are returned by `db_host()`/`db_token()`/`db_wsid()`.
+When `.databrickscfg` is enabled, the selected profile controls the host,
+credentials, authentication type, and the profile passed to `databricks auth
+token`. `{brickster}` resolves the profile in this order:
+
+1. `DATABRICKS_CONFIG_PROFILE`
+2. The `db_profile` option
+3. The CLI default selected by `databricks auth switch`
+4. The `DEFAULT` profile
+
+`DATABRICKS_CONFIG_PROFILE` is the standard Databricks unified authentication
+setting. `db_profile` is the `{brickster}` session-level equivalent.
 
 Profiles enable you to switch contexts between:
 
@@ -139,20 +155,20 @@ This behaviour works when using credentials specified in either `.Renviron` or `
 
 ```{r}
 # using .Renviron
-db_host() # returns `DB_HOST` (.Renviron)
+db_host() # returns `DATABRICKS_HOST`
 
 # switch profile to 'prod'
 options(db_profile = "prod")
-db_host() # returns `DB_HOST_PROD` (.Renviron)
+db_host() # returns `DATABRICKS_HOST_PROD`
 
-# set back to default (NULL)
+# clear the session-specific profile selection
 options(db_profile = NULL)
-# use .databrickcfg
+# use .databrickscfg
 options(use_databrickscfg = TRUE)
-db_host() # returns host from `DEFAULT` profile (.databrickscfg)
+db_host() # returns the CLI-selected default, otherwise `DEFAULT`
 
 options(db_profile = "prod")
-db_host() # returns host from `prod` profile in (.datarickscfg)
+db_host() # returns host from `prod` profile (.databrickscfg)
 ```
 
 It is expected that profiles in `.Renviron` will adhere to the same naming convention as default but add an additional suffix.
@@ -186,17 +202,49 @@ Supported OAuth fields in a `.databrickscfg` profile include:
 - Azure service principal fields: `azure_client_id`, `azure_client_secret`, `azure_tenant_id`
 - Optional auth mode override: `auth_type` (`oauth-m2m`, `azure-client-secret`, `oauth-u2m`, `databricks-cli`)
 
+#### Databricks CLI OAuth profiles
+
 Profiles created by `databricks auth login` use `auth_type = databricks-cli`.
-For these profiles, `{brickster}` calls `databricks auth token` when an API
-request is performed and keeps only the short-lived access token in memory until
-it expires. The Databricks CLI remains responsible for durable credential
+The login can be performed from any terminal; the credentials are not scoped to
+that terminal session. `{brickster}` must run as the same operating-system user
+and use the same `.databrickscfg` and CLI credential storage.
+
+Enable `.databrickscfg` and select the profile before making requests:
+
+```{r}
+options(
+  use_databrickscfg = TRUE,
+  db_profile = "e2-demo"
+)
+
+# The host and CLI token are resolved from the same profile.
+db_sql_warehouse_list()
+```
+
+Instead of `db_profile`, set `DATABRICKS_CONFIG_PROFILE`, or select the CLI
+default outside R:
+
+``` sh
+databricks auth switch --profile e2-demo
+```
+
+When a profile is selected, `{brickster}` calls `databricks auth token
+--profile <profile>`. Without a selected profile, `{brickster}` follows the
+Databricks SDK behavior and asks the CLI for the resolved host. If multiple
+profiles contain the same host, the CLI refuses to guess; select a profile
+rather than signing in again. Avoid supplying a different `host` argument while
+a profile is selected, because the request host and CLI credential would no
+longer describe the same configuration.
+
+Token acquisition is deferred until an API request is performed. `{brickster}`
+keeps only the short-lived access token in memory until it expires, then calls
+the CLI again. The Databricks CLI remains responsible for durable credential
 storage and refresh. The CLI must be available on `PATH`, or its executable can
-be provided with `DATABRICKS_CLI_PATH`.
+be provided with `DATABRICKS_CLI_PATH`. `DATABRICKS_CONFIG_FILE` is inherited by
+the CLI when using a non-default config location.
 
 The `oauth-u2m` mode remains `{brickster}`'s direct browser-based OAuth flow;
 it does not reuse credentials created by `databricks auth login`.
-
-If both `DATABRICKS_AUTH_TYPE` (environment variable) and `auth_type` (`.databrickscfg`) are set, `DATABRICKS_AUTH_TYPE` takes precedence.
 
 `wsid` is used by the connections pane integration in RStudio as the underlying API's require it.
 

--- a/vignettes/setup-auth.Rmd
+++ b/vignettes/setup-auth.Rmd
@@ -47,8 +47,6 @@ To get started add the following to your `.Renviron`:
 
 -   `ARM_TENANT_ID`: Azure AD tenant id (*only required for Azure service principal OAuth M2M*)
 
--   `DATABRICKS_AUTH_TYPE`: Optional auth mode override (`oauth-m2m`, `azure-client-secret`, `oauth-u2m`, `databricks-cli`)
-
 -   `DATABRICKS_WSID`: The workspace ID ([docs](https://docs.databricks.com/workspace/workspace-details.html#workspace-instance-names-urls-and-ids))
 
 `DATABRICKS_WSID` is only required for the RStudio IDE integration with the connection pane.
@@ -127,9 +125,10 @@ db_token()
 ```
 
 With its default value of `FALSE`, `{brickster}` does not discover profiles
-created by `databricks auth login`. Set the option in `.Rprofile` when
-`.databrickscfg` should be the normal configuration source. Posit Workbench
-managed OAuth sessions enable `.databrickscfg` automatically.
+created by `databricks auth login` and does not enable the `databricks-cli`
+authentication provider. Set the option in `.Rprofile` when `.databrickscfg`
+should be the normal configuration source. Posit Workbench managed OAuth
+sessions enable `.databrickscfg` automatically.
 
 ### Switching Between Credentials
 
@@ -208,6 +207,10 @@ Profiles created by `databricks auth login` use `auth_type = databricks-cli`.
 The login can be performed from any terminal; the credentials are not scoped to
 that terminal session. `{brickster}` must run as the same operating-system user
 and use the same `.databrickscfg` and CLI credential storage.
+
+The `databricks-cli` provider is intentionally available only when the selected
+`.databrickscfg` profile contains `auth_type = databricks-cli`. Environment
+configuration cannot activate this provider independently.
 
 Enable `.databrickscfg` and select the profile before making requests:
 

--- a/vignettes/setup-auth.Rmd
+++ b/vignettes/setup-auth.Rmd
@@ -77,7 +77,7 @@ ARM_CLIENT_SECRET=abcdefg1234567890
 ARM_TENANT_ID=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
 ```
 
-With no explicit auth override, `{brickster}` attempts Databricks OAuth M2M (`DATABRICKS_CLIENT_*`), then Azure service principal OAuth M2M (`ARM_*`), then OAuth U2M. Set `DATABRICKS_AUTH_TYPE=azure-client-secret` to force Azure service principal authentication.
+With no `auth_type` in a selected `.databrickscfg` profile, `{brickster}` attempts Databricks OAuth M2M (`DATABRICKS_CLIENT_*`), then Azure service principal OAuth M2M (`ARM_*`), then OAuth U2M. When using `.databrickscfg`, set `auth_type = azure-client-secret` in the profile to force Azure service principal authentication.
 
 **Note**: Recommend creating an `.Renviron` for each project. You can create `.Renviron` within your user home directory if required.
 

--- a/vignettes/setup-auth.Rmd
+++ b/vignettes/setup-auth.Rmd
@@ -180,11 +180,21 @@ For details on configuring please refer to [documentation from Databricks CLI](h
 
 There is only one `{brickster}` specific feature and it is the inclusion of `wsid` alongside `host`/`token`.
 
-When using OAuth M2M with a `.databrickscfg` profile:
+Supported OAuth fields in a `.databrickscfg` profile include:
 
 - Databricks service principal fields: `client_id`, `client_secret`
 - Azure service principal fields: `azure_client_id`, `azure_client_secret`, `azure_tenant_id`
-- Optional auth mode override: `auth_type` (`oauth-m2m`, `azure-client-secret`, `oauth-u2m`)
+- Optional auth mode override: `auth_type` (`oauth-m2m`, `azure-client-secret`, `oauth-u2m`, `databricks-cli`)
+
+Profiles created by `databricks auth login` use `auth_type = databricks-cli`.
+For these profiles, `{brickster}` calls `databricks auth token` when an API
+request is performed and keeps only the short-lived access token in memory until
+it expires. The Databricks CLI remains responsible for durable credential
+storage and refresh. The CLI must be available on `PATH`, or its executable can
+be provided with `DATABRICKS_CLI_PATH`.
+
+The `oauth-u2m` mode remains `{brickster}`'s direct browser-based OAuth flow;
+it does not reuse credentials created by `databricks auth login`.
 
 If both `DATABRICKS_AUTH_TYPE` (environment variable) and `auth_type` (`.databrickscfg`) are set, `DATABRICKS_AUTH_TYPE` takes precedence.
 


### PR DESCRIPTION
## Summary

- route `auth_type = databricks-cli` through `databricks auth token` instead of the direct OAuth client
- keep provider selection bound to the selected `.databrickscfg` profile and follow the Databricks Python SDK profile precedence
- convert CLI responses into `httr2_token` credentials while leaving durable credentials and refresh to the CLI
- refresh OAuth tokens 40 seconds before expiry using the new httr2 1.3.0 expiry margin
- document the CLI authentication workflow and add offline coverage for routing, failures, expiry, cache reuse, and workspace isolation

## Root cause

Brickster treated every tokenless request as a direct OAuth flow. Profiles created by `databricks auth login` identify `databricks-cli` as an external credential provider, so passing that value into Brickster's OAuth client could not reuse the CLI's secure credential storage. Older CLI versions appeared to work because they wrote a reusable token into the profile, which bypassed this tokenless OAuth path.

Databricks also rejects access tokens with 30 seconds or less remaining. Earlier httr2 releases could reuse those tokens because they only treated tokens as expired five seconds early. httr2 1.3.0 exposes an expiry margin through its normal refresh path, so Brickster now uses the same 40-second buffer as the Databricks Python SDK without manipulating cache internals.

Fixes #253.
Fixes #257.

## Validation

- full `devtools::test(reporter = "summary")` suite with httr2 1.3.0 — passed; 21 expected live-workspace skips
- focused request/auth tests cover M2M, U2M, and CLI refresh with 35 seconds remaining
- Air formatting check on modified R code and tests
- `git diff --check`
- repository pre-commit and pre-push secret scans
